### PR TITLE
Support escript by rebar3 escriptize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 
 -----------------
-##observer_cli
+#observer_cli
 [![Build Status](https://travis-ci.org/zhongwencool/observer_cli.svg?branch=master)](https://travis-ci.org/zhongwencool/observer_cli)
 [![Hex.pm](https://img.shields.io/hexpm/v/observer_cli.svg)](http://hex.pm/packages/observer_cli)
 
 Visualize Erlang/Elixir Nodes On The Command Line By Using [recon](https://github.com/ferd/recon).
+
+[Animation Show](http://zhongwencool.github.io/observer_cli/).
 
 ##Goal
 Minimal consumption.
@@ -15,30 +17,39 @@ you might think observer_cli would be more convenient than observer.
 
 ------------------
 ###Install
-Elixir
-
+**Erlang**
+```erlang
+%% rebar.config
+{deps, [observer_cli]}
+```
+**Elixir**
 ```ex
 # mix.exs
    def deps do
-     [{:observer_cli, "~> 1.0.9"}]
+     [{:observer_cli, "~> 1.1.0"}]
    end
    def application do
      [applications: [:observer_cli]]
   end
 ```
-Erlang 
-
-```erlang
-%% rebar.config
-{deps, [observer_cli]}
-```
 ------------------
-###Try ...
+###Try In Shell
 
 ```bash
 $ rebar3 shell
 1> observer_cli:start().
 ```
+
+###Escriptize
+1. `rebar3 escriptize` to generate an escript executable containing the project's and its dependencies' BEAM files.
+
+    Place script(`_build/default/bin/observer_cli`) anywhere in your path and use `observer_cli` command.
+    
+2. `observer_cli <TARGETNODE> <TARGETCOOKIE>` to monitor remote node. 
+   
+   :exclamation: **ensure obsever_cli application start on target node.**
+
+----------------
 ### Process And System Information
  
 ![Top](http://7q5a9k.com1.z0.glb.clouddn.com/observer_cli_home_2015_12_26.jpg)
@@ -56,7 +67,6 @@ $ rebar3 shell
 
 ### Help Information
 ![Help](http://7q5a9k.com1.z0.glb.clouddn.com/observer_cli_help_20151226.jpg)
-
 
 ----------------
 ###Command
@@ -79,6 +89,15 @@ $ rebar3 shell
 - [ ] ~~Draw all application’s relations.~~
 - [ ] ~~Trace Overview.~~ You should use recon_trace.
 
+----------------
+###Changelog
+
+- 1.1.0
+  - Support escript, `observer_cli <TARGETNODE> <COOKIE>`
+  
+- 1.0.9
+  - Upgrade rebar3 to 3.3.3 for publish hex repo.
+    
 --------------------
 ###License
 See the [LICENSE](https://github.com/zhongwencool/observer_cli/blob/master/LICENSE) file for license rights and limitations (MIT).

--- a/include/observer_cli.hrl
+++ b/include/observer_cli.hrl
@@ -1,30 +1,30 @@
 
 -define(COLUMN_WIDTH, 133).
 
--define(SYSTEM_MIN_INTERVAL, 5000).
--define(ALLOCATOR_MIN_INTERVAL, 5000).
+-define(SYSTEM_MIN_INTERVAL, 2000).
+-define(ALLOCATOR_MIN_INTERVAL, 2000).
 -define(HOME_MIN_INTERVAL, 1000).
 -define(HELP_MIN_INTERVAL, 1000).
 -define(PROCESS_MIN_INTERVAL, 1000).
--define(MNESIA_MIN_INTERVAL, 5000).
+-define(MNESIA_MIN_INTERVAL, 2000).
 -define(INET_MIN_INTERVAL, 1000).
 
 -record(home, {func = proc_count :: atom(),
                type = memory :: atom(),
                cur_pos = 1 :: integer(),
-               rows = 26 :: integer(),
+               rows = 18 :: integer(),
                interval = ?SYSTEM_MIN_INTERVAL :: integer()}).
 
 -record(system, {interval = ?SYSTEM_MIN_INTERVAL :: integer(),
-                 rows = 30 :: integer()}).
+                 rows = 22 :: integer()}).
 -record(allocate, {interval = ?SYSTEM_MIN_INTERVAL :: integer()}).
 
 -record(db, {interval = ?MNESIA_MIN_INTERVAL :: integer(),
-             rows = 37 :: integer()}).
+             rows = 29 :: integer()}).
 
 -record(help, {interval = ?HELP_MIN_INTERVAL :: integer()}).
 -record(inet, {interval = ?INET_MIN_INTERVAL :: integer(),
-               rows = 38 :: integer(),
+               rows = 30 :: integer(),
                func = inet_count :: atom(),
                type = cnt :: atom()}).
 

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,11 @@
             warn_untyped_record, debug_info]}.
 {deps_dir, "deps"}.
 {deps, [recon]}.
+
+{escript_main_app, observer_cli}.
+{escript_emu_args, "%%! -name observer_cli@127.0.0.1 -escript main observer_cli_escriptize +sbtu +A0 -elixir ansi_enabled true\n"}.
+{escript_incl_apps, [recon]}.
+
 {dialyzer_opts, [{warnings, [unmatched_returns, error_handling, race_conditions, behaviours]}]}.
 {edoc_opts, [{report_missing_types, true}, {source_path, ["src"]}, {report_missing_types, true}, {todo, true}, {packages, false}, {subpackages, false}]}.
 {xref_checks, [undefined_function_calls]}.

--- a/src/observer_cli.app.src
+++ b/src/observer_cli.app.src
@@ -1,7 +1,7 @@
 {application, observer_cli,
  [
   {description, "Visualize Erlang Nodes On The Command Line"},
-  {vsn, "1.0.9"},
+  {vsn, "1.1.0"},
   {modules, [
              observer_cli
             ]},

--- a/src/observer_cli_escriptize.erl
+++ b/src/observer_cli_escriptize.erl
@@ -1,0 +1,14 @@
+-module(observer_cli_escriptize).
+
+-export([main/1]).
+
+%% @doc escript main
+-spec main(list()) -> no_return.
+
+main([TargetNode, Cookie]) ->
+    TargetNodeAtom = list_to_atom(TargetNode),
+    CookieAtom = list_to_atom(Cookie),
+    observer_cli:start(TargetNodeAtom, CookieAtom);
+main(_Options) ->
+    io:format("Usage: observer_cli <TARGETNODE> <TARGETCOOKIE>~n").
+

--- a/src/observer_cli_inet.erl
+++ b/src/observer_cli_inet.erl
@@ -30,8 +30,10 @@ start(Node, #view_opts{inet = #inet{interval = Interval,
       Ms:: integer().
 get_inet_info(local_node, Function, Type, Rows, Ms, Count) -> 
     inet_info(Function, Type, Rows, Ms, Count);
-get_inet_info(Node, Function, Type, Rows, Ms, Count) ->
-    rpc:call(Node, ?MODULE, get_inet_info, [local_node, Function, Type, Rows, Ms, Count]).
+get_inet_info(_Node, _Function, _Type, _Rows, _Ms, _Count) ->
+    io:format("\e[48;2;184;0;0mDon't Support remote node. erlang:port_info/2 badarg if Port is not a local port identifier.\e[0m~n"),
+    io:format("You can see Net by observer_cli:start/0 on local node.~n"),
+    [].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Private


### PR DESCRIPTION
**Escriptize**
1. `rebar3 escriptize` to generate an escript executable containing the project's and its dependencies' BEAM files.

    Place script(`_build/default/bin/observer_cli`) anywhere in your path and use `observer_cli` command.
    
2. `observer_cli <TARGETNODE> <TARGETCOOKIE>` to monitor remote node. 
   
   :exclamation: **ensure obsever_cli application start on target node.**