### PR TITLE
Adjust ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ otp_release:
   - 18.3
   - 17.5
   - R16B03-1
-  - R15B03
 
 env:
   - PATH=$HOME/.cache/rebar3/bin/:$PATH

--- a/include/observer_cli.hrl
+++ b/include/observer_cli.hrl
@@ -28,7 +28,7 @@
     help = #help{} :: help(),
     inet = #inet{} :: inet(),
     process = #process{} :: process(),
-    terminal_row :: integer()
+    auto_row = true :: boolean()
 }).
 
 -export_type([view_opts/0]).

--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -11,9 +11,8 @@
 -define(CPU_ALARM_THRESHOLD, 0.8). %% cpu >= this value will be highlight
 -define(COUNT_ALARM_THRESHOLD, 0.85). %% port or process reach max_limit * 0.85 will be highlight
 -define(FAST_COLLECT_INTERVAL, 0). %% collect should be fast when we push the keyboard to switch mode
--define(DEFAULT_ROW_SIZE, 47). %% the number from 13' mbp
 
--define(STABLE_SYSTEM_ITEM, [system_version, process_limit, smp_support,
+-define(STABLE_SYSTEM_KEY, [system_version, process_limit, smp_support,
     port_limit, ets_limit, logical_processors, multi_scheduling]).
 
 -spec start() -> no_return.
@@ -22,15 +21,16 @@ start() -> start(#view_opts{}).
 -spec start(Node) -> no_return when Node :: atom().
 start(Node) when Node =:= node() -> start(#view_opts{});
 start(Node) when is_atom(Node) -> rpc_start(Node);
-start(#view_opts{home = Home = #home{tid = undefined},
-    terminal_row = TerminalRow} = Opts) ->
-    Tid = ets:new(process_info, [public, set]),
-    NewHome = Home#home{tid = Tid},
-    ChildPid = spawn(fun() -> render_worker(TerminalRow, NewHome) end),
-    manager(ChildPid, Opts#view_opts{home = NewHome});
-start(#view_opts{home = Home, terminal_row = TerminalRow} = Opts) ->
-    ChildPid = spawn(fun() -> render_worker(TerminalRow, Home) end),
-    manager(ChildPid, Opts).
+start(#view_opts{home = #home{tid = undefined}} = Opts) ->
+    Tid = ets:new(observer_cli_top_n, [public, set]),
+    AutoRow = check_auto_row(),
+    NewHome = #home{tid = Tid},
+    ChildPid = spawn(fun() -> render_worker(NewHome, AutoRow) end),
+    manager(ChildPid, Opts#view_opts{home = NewHome, auto_row = AutoRow});
+start(#view_opts{home = Home} = Opts) ->
+    AutoRow = check_auto_row(),
+    ChildPid = spawn(fun() -> render_worker(Home, AutoRow) end),
+    manager(ChildPid, Opts#view_opts{auto_row = AutoRow}).
 
 -spec start(Node, Cookies) -> no_return when
     Node :: atom(),
@@ -46,14 +46,9 @@ start(Node, Cookie) when is_atom(Node) andalso is_atom(Cookie) ->
 rpc_start(Node) ->
     case net_kernel:connect_node(Node) of
         true ->
-            TerminalRow =
-                case io:rows() of
-                    {error, _} -> ?DEFAULT_ROW_SIZE;
-                    {ok, _} -> undefined
-                end,
-            rpc:call(Node, ?MODULE, start, [#view_opts{terminal_row = TerminalRow}]);
-        false -> connect_error(<<"Remote node ~p(cookie:~p) refuse to be connected ~n">>, Node);
-        ignored -> connect_error(<<"Ignore remote node~p(cookie:~p) connecting~n">>, Node)
+            rpc:call(Node, ?MODULE, start, [#view_opts{}]);
+        false -> connect_error(<<"Node(~p) refuse to be connected, make sure cookie is valid~n">>, Node);
+        ignored -> connect_error(<<"Ignored by node(~p), local node is not alive!~n">>, Node)
     end.
 
 manager(ChildPid, Opts) ->
@@ -77,117 +72,126 @@ manager(ChildPid, Opts) ->
         _ -> manager(ChildPid, Opts)
     end.
 
-render_worker(TerminalRow, #home{} = Home) ->
+render_worker(#home{} = Home, AutoRow) ->
     ?output(?CLEAR),
     StableInfo = get_stable_system_info(),
-    redraw(running, StableInfo, erlang:make_ref(), 0, Home, TerminalRow).
+    redraw_running(Home, StableInfo, erlang:make_ref(), AutoRow, true).
 
 %% pause status waiting to be resume
-redraw(pause, StableInfo, LastTimeRef, _, #home{func = Func, type = Type} = Home, TerminalRow) ->
+redraw_pause(#home{func = Func, type = Type} = Home, StableInfo, LastTimeRef, AutoRow) ->
     notify_pause_status(),
     erlang:cancel_timer(LastTimeRef),
     receive
         quit -> quit;
         pause_or_resume ->
             ?output(?CLEAR),
-            redraw(running, StableInfo, LastTimeRef, ?FAST_COLLECT_INTERVAL, Home, TerminalRow);
+            redraw_running(Home, StableInfo, LastTimeRef, AutoRow, true);
         {Func, Type} ->
-            redraw(running, StableInfo, LastTimeRef, ?FAST_COLLECT_INTERVAL, Home, TerminalRow)
-    end;
+            redraw_running(Home, StableInfo, LastTimeRef, AutoRow, false)
+    end.
+
 %% running status
-redraw(running, StableInfo, LastTimeRef, NodeStatsCostTime, #home{tid = Tid,
-    interval = Interval, func = Func, type = Type, cur_pos = RankPos} = Home, TerminalRow0) ->
-    TerminalRow = observer_cli_lib:to_row(TerminalRow0),
+redraw_running(#home{tid = Tid, interval = Interval, func = Func, type = Type, cur_pos = RankPos} = Home,
+    StableInfo, LastTimeRef, AutoRow, IsFirstTime) ->
     erlang:cancel_timer(LastTimeRef),
-    [{ProcSum, MemSum}] = recon:node_stats_list(1, NodeStatsCostTime),
-    {CPURow, CPULine} = render_scheduler_usage(MemSum),
-    Rows = max(TerminalRow - 14 - CPURow, 0),
-    {RankList, RankCostTime} = get_ranklist_and_cost_time(Func, Type, Interval, Rows, NodeStatsCostTime),
-    [UseMemInt, AllocatedMemInt, UnusedMemInt] = get_change_system_info(),
-    NewNodeStatsCostTime = Interval div 2,
-    Text = get_refresh_cost_info(Func, Type, Interval, Rows),
+    TerminalRow = observer_cli_lib:get_terminal_rows(AutoRow),
+    [{Processes, Schedulers}] = recon:node_stats(1, 0, fun(X, Acc) -> [X|Acc] end, []),
+    {CPURow, CPULine} = render_scheduler_usage(Schedulers),
+    ProcessRows = max(TerminalRow - 14 - CPURow, 0),
+    TopList = get_top_n(Func, Type, Interval, ProcessRows, IsFirstTime),
+    {UseMemInt, AllocatedMemInt, UnusedMemInt} = get_change_system_info(),
+    Text = get_refresh_prompt(Func, Type, Interval, ProcessRows),
     MenuLine = observer_cli_lib:render_menu(home, Text, 133),
-    SystemLine = render_system_line(StableInfo, UseMemInt, AllocatedMemInt, UnusedMemInt, ProcSum),
-    MemLine = render_memory_process_line(ProcSum, MemSum, NewNodeStatsCostTime),
-    {PidList, RankLine} = render_process_rank(Type, RankList, Rows, RankPos),
+    SystemLine = render_system_line(StableInfo, UseMemInt, AllocatedMemInt, UnusedMemInt, Processes),
+    MemLine = render_memory_process_line(Processes, Schedulers, Interval),
+    {PidList, RankLine} = render_top_n_view(Type, TopList, ProcessRows, RankPos),
     LastLine = render_last_line(),
     ?output([?CURSOR_TOP, MenuLine, SystemLine, MemLine, CPULine, RankLine, LastLine]),
     
     catch ets:insert(Tid, PidList),
-    TimeRef = refresh_next_time(Func, Type, Interval, RankCostTime, NodeStatsCostTime),
+    TimeRef = refresh_next_time(Func, Type, Interval),
     receive
         quit -> quit;
-        pause_or_resume -> redraw(pause, StableInfo, TimeRef, ?FAST_COLLECT_INTERVAL, Home, TerminalRow0);
-        {Func, Type} -> redraw(running, StableInfo, TimeRef, NewNodeStatsCostTime, Home, TerminalRow0)
+        pause_or_resume -> redraw_pause(Home, StableInfo, TimeRef, AutoRow);
+        {Func, Type} -> redraw_running(Home, StableInfo, TimeRef, AutoRow, false)
     end.
 
-render_system_line(StableInfo, UseMemInt, AllocatedMemInt, UnusedMemInt, ProcSum) ->
+render_system_line(StableInfo, UseMem, AllocatedMem, UnusedMem, ProcSum) ->
     [Version, ProcLimit, SmpSupport, PortLimit, EtsLimit, LogicalProc, MultiScheduling] = StableInfo,
-    UseMem = observer_cli_lib:byte_to_str(UseMemInt),
-    AllocatedMem = observer_cli_lib:byte_to_str(AllocatedMemInt),
-    UnUsedMem = observer_cli_lib:byte_to_str(UnusedMemInt),
-    UsePercent = observer_cli_lib:float_to_percent_with_two_digit(UseMemInt / AllocatedMemInt),
-    UnUsePercent = observer_cli_lib:float_to_percent_with_two_digit(UnusedMemInt / AllocatedMemInt),
-    {PortWarning, ProcWarning, PortCount, ProcCount} = get_port_proc_count_info(PortLimit, ProcLimit, ProcSum),
+    UsePercent = observer_cli_lib:to_percent(UseMem / AllocatedMem),
+    UnUsePercent = observer_cli_lib:to_percent(UnusedMem / AllocatedMem),
+    {PortWarning, ProcWarning, PortCount, ProcCount} = get_port_proc_info(PortLimit, ProcLimit, ProcSum),
     VersionLine = ?render([?W(Version -- "\n", 138)]),
     Title = ?render([?GRAY_BG,
         ?W("System", 10), ?W("Count/Limit", 21),
-        ?W("System Switch", 20), ?W("State", 24),
-        ?W("Memory Info", 20), ?W("Size", 28),
+        ?W("System Switch", 25), ?W("Status", 21),
+        ?W("Memory Info", 20), ?W("Size", 26),
         ?RESET]),
     Row1 = ?render([
-        ?W("Proc Count", 10), ?W(ProcWarning, ProcCount, 21), ?W("Smp Support", 20),
-        ?W(SmpSupport, 24), ?W("Allocted Mem", 20), ?W(AllocatedMem, 19), ?W("100.0%", 6)
+        ?W("Proc Count", 10), ?W(ProcWarning, ProcCount, 21),
+        ?W("Smp Support", 25), ?W(SmpSupport, 21),
+        ?W("Allocted Mem", 20), ?W({byte, AllocatedMem}, 17), ?W("100.0%", 6)
     ]),
     Row2 = ?render([
-        ?W("Port Count", 10), ?W(PortWarning, PortCount, 21), ?W("Multi Scheduling", 20),
-        ?W(MultiScheduling, 24), ?W("Use Mem", 20), ?W(UseMem, 19), ?W(UsePercent, 6)
+        ?W("Port Count", 10), ?W(PortWarning, PortCount, 21),
+        ?W("Multi Scheduling", 25), ?W(MultiScheduling, 21),
+        ?W("Use Mem", 20), ?W({byte, UseMem}, 17), ?W(UsePercent, 6)
     ]),
     Row3 = ?render([
-        ?UNDERLINE, ?W("Ets Limit", 10), ?W(EtsLimit, 21), ?W("Logical Processors", 20),
-        ?W(LogicalProc, 24), ?W("Unuse Mem", 20), ?W(UnUsedMem, 19),
-        ?W(UnUsePercent, 6), ?RESET]),
+        ?UNDERLINE, ?W("Ets Limit", 10), ?W(EtsLimit, 21),
+        ?W("Logical Processors", 25), ?W(LogicalProc, 21),
+        ?W("Unuse Mem", 20), ?W({byte, UnusedMem}, 17), ?W(UnUsePercent, 6),
+        ?RESET]),
     [VersionLine, Title, Row1, Row2, Row3].
 
 render_memory_process_line(ProcSum, MemSum, Interval) ->
-    TotalMemInt = proplists:get_value(memory_total, ProcSum),
-    TotalMem = observer_cli_lib:byte_to_str(TotalMemInt),
-    ProcMemInt = proplists:get_value(memory_procs, ProcSum),
-    ProcMem = observer_cli_lib:byte_to_str(ProcMemInt),
-    ProcMemPercent = observer_cli_lib:float_to_percent_with_two_digit(ProcMemInt / TotalMemInt),
-    AtomMemInt = proplists:get_value(memory_atoms, ProcSum),
-    AtomMem = observer_cli_lib:byte_to_str(AtomMemInt),
-    AtomMemPercent = observer_cli_lib:float_to_percent_with_two_digit(AtomMemInt / TotalMemInt),
-    BinMemInt = proplists:get_value(memory_bin, ProcSum),
-    BinMem = observer_cli_lib:byte_to_str(BinMemInt),
-    BinMemPercent = observer_cli_lib:float_to_percent_with_two_digit(BinMemInt / TotalMemInt),
-    CodeMemInt = erlang:memory(code),
-    CodeMem = observer_cli_lib:byte_to_str(CodeMemInt),
-    CodeMemPercent = observer_cli_lib:float_to_percent_with_two_digit(CodeMemInt / TotalMemInt),
-    EtsMemInt = proplists:get_value(memory_ets, ProcSum),
-    EtsMem = observer_cli_lib:byte_to_str(EtsMemInt),
-    EtsMemPercent = observer_cli_lib:float_to_percent_with_two_digit(EtsMemInt / TotalMemInt),
-    RunQueue = integer_to_list(proplists:get_value(run_queue, ProcSum)),
-    BytesIn = observer_cli_lib:byte_to_str(proplists:get_value(bytes_in, MemSum)),
-    BytesOut = observer_cli_lib:byte_to_str(proplists:get_value(bytes_out, MemSum)),
-    GcCount = observer_cli_lib:to_list(proplists:get_value(gc_count, MemSum)),
-    GcWordsReclaimed = observer_cli_lib:to_list(proplists:get_value(gc_words_reclaimed, MemSum)),
-    Reductions = integer_to_list(proplists:get_value(reductions, MemSum)),
+    CodeMem = erlang:memory(code),
+    [
+        {process_count, _ProcC},
+        {run_queue, RunQ},
+        {error_logger_queue_len, LogQInt},
+        {memory_total, TotalMem},
+        {memory_procs, ProcMem},
+        {memory_atoms, AtomMem},
+        {memory_bin, BinMem},
+        {memory_ets, EtsMem}|_
+    ] = ProcSum,
+    [
+        {bytes_in, BytesIn},
+        {bytes_out, BytesOut},
+        {gc_count, GcCount},
+        {gc_words_reclaimed, GcWordsReclaimed},
+        {reductions, Reductions}|_
+    ] = MemSum,
+    
+    ProcMemPercent = observer_cli_lib:to_percent(ProcMem / TotalMem),
+    AtomMemPercent = observer_cli_lib:to_percent(AtomMem / TotalMem),
+    BinMemPercent = observer_cli_lib:to_percent(BinMem / TotalMem),
+    CodeMemPercent = observer_cli_lib:to_percent(CodeMem / TotalMem),
+    EtsMemPercent = observer_cli_lib:to_percent(EtsMem / TotalMem),
+    
+    Queue = erlang:integer_to_list(RunQ) ++ "/" ++ erlang:integer_to_list(LogQInt),
     Row1 = ?render([
-        ?GRAY_BG, ?W("Memory", 10), ?W("Size", 21), ?W("Memory", 20), ?W("Size", 24),
-        ?W("IO/GC", 20), ?W("Interval: " ++ integer_to_list(Interval) ++ "ms", 28), ?RESET]),
+        ?GRAY_BG, ?W("Mem Type", 10), ?W("Size", 21),
+        ?W("Mem Type", 25), ?W("Size", 21),
+        ?W("IO/GC", 20), ?W(["Interval: ", integer_to_binary(Interval), "ms"], 26),
+        ?RESET]),
     Row2 = ?render([
-        ?W("Total", 10), ?W(TotalMem, 12), ?W("100%", 6), ?W("Binary", 20),
-        ?W(BinMem, 15), ?W(BinMemPercent, 6), ?W("IO Output", 20), ?W(BytesOut, 28)]),
+        ?W("Total", 10), ?W({byte, TotalMem}, 12), ?W("100.0%", 6),
+        ?W("Binary", 25), ?W({byte, BinMem}, 12), ?W(BinMemPercent, 6),
+        ?W("IO Output", 20), ?W({byte, BytesOut}, 26)]),
     Row3 = ?render([
-        ?W("Process", 10), ?W(ProcMem, 12), ?W(ProcMemPercent, 6), ?W("Code", 20),
-        ?W(CodeMem, 15), ?W(CodeMemPercent, 6), ?W("IO Input", 20), ?W(BytesIn, 28)]),
+        ?W("Process", 10), ?W({byte, ProcMem}, 12), ?W(ProcMemPercent, 6),
+        ?W("Code", 25), ?W({byte, CodeMem}, 12), ?W(CodeMemPercent, 6),
+        ?W("IO Input", 20), ?W({byte, BytesIn}, 26)]),
     Row4 = ?render([
-        ?W("Atom", 10), ?W(AtomMem, 12), ?W(AtomMemPercent, 6), ?W("Reductions", 20),
-        ?W(Reductions, 24), ?W("Gc Count", 20), ?W(GcCount, 28)]),
+        ?W("Atom", 10), ?W({byte, AtomMem}, 12), ?W(AtomMemPercent, 6),
+        ?W("Reductions", 25), ?W(Reductions, 21),
+        ?W("Gc Count", 20), ?W(GcCount, 26)]),
     Row5 = ?render([
-        ?W("Ets", 10), ?W(EtsMem, 12), ?W(EtsMemPercent, 6), ?W("Run Queue", 20),
-        ?W(RunQueue, 24), ?W("Gc Words Reclaimed", 20), ?W(GcWordsReclaimed, 28)]),
+        ?W("Ets", 10), ?W({byte, EtsMem}, 12), ?W(EtsMemPercent, 6),
+        ?W("RunQueue/ErrorLoggerQueue", 25), ?W(Queue, 21),
+        ?W("Gc Words Reclaimed", 20), ?W(GcWordsReclaimed, 26)]),
     [Row1, Row2, Row3, Row4, Row5].
 
 render_scheduler_usage(MemSum) ->
@@ -203,19 +207,16 @@ render_scheduler_usage(SchedulerUsage, SchedulerNum) when SchedulerNum =< 8 ->
              Seq2 = Seq1 + HalfSchedulerNum,
              Percent1 = proplists:get_value(Seq1, SchedulerUsage),
              Percent2 = proplists:get_value(Seq2, SchedulerUsage),
-             CPU1 = observer_cli_lib:float_to_percent_with_two_digit(Percent1),
-             CPU2 = observer_cli_lib:float_to_percent_with_two_digit(Percent2),
-             CPUSeq1 = lists:flatten(io_lib:format("~2..0w", [Seq1])),
-             CPUSeq2 = lists:flatten(io_lib:format("~2..0w", [Seq2])),
+             CPU1 = observer_cli_lib:to_percent(Percent1),
+             CPU2 = observer_cli_lib:to_percent(Percent2),
              Process1 = lists:duplicate(trunc(Percent1 * 57), "|"),
              Process2 = lists:duplicate(trunc(Percent2 * 57), "|"),
-             Format = cpu_format_alarm_color(Percent1, Percent2),
-             case Seq1 =:= HalfSchedulerNum of
-                 false -> io_lib:format(Format, [CPUSeq1, Process1, CPU1, CPUSeq2, Process2, CPU2]);
-                 true ->
-                     io_lib:format(<<?UNDERLINE/binary, Format/binary, ?RESET/binary>>,
-                         [CPUSeq1, Process1, CPU1, CPUSeq2, Process2, CPU2])
-             end
+             IsLastLine = Seq1 =:= HalfSchedulerNum,
+             Format = process_bar_format_style(Percent1, Percent2, IsLastLine),
+             io_lib:format(Format, [
+                 Seq1, Process1, CPU1,
+                 Seq2, Process2, CPU2
+             ])
          end || Seq1 <- lists:seq(1, HalfSchedulerNum)],
     {HalfSchedulerNum, CPU};
 %% >= 8 will split 4 part
@@ -230,89 +231,86 @@ render_scheduler_usage(SchedulerUsage, SchedulerNum) ->
              Percent2 = proplists:get_value(Seq2, SchedulerUsage),
              Percent3 = proplists:get_value(Seq3, SchedulerUsage),
              Percent4 = proplists:get_value(Seq4, SchedulerUsage),
-             CPU1 = observer_cli_lib:float_to_percent_with_two_digit(Percent1),
-             CPU2 = observer_cli_lib:float_to_percent_with_two_digit(Percent2),
-             CPU3 = observer_cli_lib:float_to_percent_with_two_digit(Percent3),
-             CPU4 = observer_cli_lib:float_to_percent_with_two_digit(Percent4),
-             CPUSeq1 = lists:flatten(io_lib:format("~2..0w", [Seq1])),
-             CPUSeq2 = lists:flatten(io_lib:format("~2..0w", [Seq2])),
-             CPUSeq3 = lists:flatten(io_lib:format("~2..0w", [Seq3])),
-             CPUSeq4 = lists:flatten(io_lib:format("~2..0w", [Seq4])),
+             CPU1 = observer_cli_lib:to_percent(Percent1),
+             CPU2 = observer_cli_lib:to_percent(Percent2),
+             CPU3 = observer_cli_lib:to_percent(Percent3),
+             CPU4 = observer_cli_lib:to_percent(Percent4),
              Process1 = lists:duplicate(trunc(Percent1 * 23), "|"),
              Process2 = lists:duplicate(trunc(Percent2 * 22), "|"),
              Process3 = lists:duplicate(trunc(Percent3 * 22), "|"),
              Process4 = lists:duplicate(trunc(Percent4 * 23), "|"),
-             Format = cpu_format_alarm_color(Percent1, Percent2, Percent3, Percent4),
-             case Seq1 =:= PosSchedulerNum of
-                 false ->
-                     io_lib:format(Format, [CPUSeq1, Process1, CPU1, CPUSeq2, Process2, CPU2,
-                         CPUSeq3,Process3, CPU3, CPUSeq4,Process4, CPU4]);
-                 true ->
-                     io_lib:format(<<?UNDERLINE/binary, Format/binary, ?RESET/binary>>,
-                         [CPUSeq1, Process1, CPU1, CPUSeq2, Process2, CPU2,
-                             CPUSeq3, Process3, CPU3, CPUSeq4,Process4, CPU4])
-             end
+             IsLastLine = Seq1 =:= PosSchedulerNum,
+             Format = process_bar_format_style(Percent1, Percent2, Percent3, Percent4, IsLastLine),
+             io_lib:format(Format, [
+                 Seq1, Process1, CPU1,
+                 Seq2, Process2, CPU2,
+                 Seq3, Process3, CPU3,
+                 Seq4, Process4, CPU4
+             ])
          end || Seq1 <- lists:seq(1, PosSchedulerNum)],
     {PosSchedulerNum, CPU}.
 
-render_process_rank(memory, MemoryList, Num, RankPos) ->
+render_top_n_view(memory, MemoryList, Num, RankPos) ->
     Title = ?render([
-        ?W("Pid", 15), ?W(?RED, "Memory", 11),
-        ?W("Name or Initial Call", 30),
+        ?W("Pid", 15), ?W(?RED, "Memory", 11), ?W("Name or Initial Call", 30),
         ?W("Reductions", 10), ?W("Msg Queue", 10), ?W("Current Function", 47),
         ?RESET]),
     {Rows, ProcList} =
         lists:foldr(fun(Pos, {Acc1, Acc2}) ->
-            {Pid, MemVal, Call = [IsName | _]} = lists:nth(Pos, MemoryList),
-            [{_, Reductions}, {_, MsgQueueLen}] = get_reductions_and_msg_queue_len(Pid),
-            {CurFun, InitialCall} = get_current_initial_call(Call),
-            NameOrCall = display_name_or_initial_call(IsName, InitialCall),
-            Format = get_choose_format(RankPos, Pos),
+            {Pid, MemVal, CurFun, NameOrCall} = get_top_n_info(Pos, MemoryList),
+            {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
+            Format = get_top_n_format(RankPos, Pos),
             R = io_lib:format(Format,
-                [observer_cli_lib:to_list(Pos), pid_to_list(Pid), observer_cli_lib:byte_to_str(MemVal), NameOrCall,
-                    observer_cli_lib:to_list(Reductions), observer_cli_lib:to_list(MsgQueueLen), CurFun]),
+                [
+                    Pos, erlang:pid_to_list(Pid),
+                    observer_cli_lib:to_byte(MemVal), NameOrCall,
+                    observer_cli_lib:to_list(Reductions),
+                    observer_cli_lib:to_list(MsgQueueLen), CurFun
+                ]),
             {[R | Acc1], [{Pos, Pid} | Acc2]}
                     end, {[], []}, lists:seq(1, erlang:min(Num, erlang:length(MemoryList)))),
     {ProcList, [Title | Rows]};
-render_process_rank(binary_memory, MemoryList, Num, RankPos) ->
+render_top_n_view(binary_memory, MemoryList, Num, RankPos) ->
     Title = ?render([
-        ?W("Pid", 15), ?W(?RED, "BinMemory", 11),
-        ?W("Name or Initial Call", 30),
+        ?W("Pid", 15), ?W(?RED, "BinMemory", 11), ?W("Name or Initial Call", 30),
         ?W("Reductions", 10), ?W("Msg Queue", 10), ?W("Current Function", 47),
         ?RESET]),
     {Rows, ProcList} =
         lists:foldr(fun(Pos, {Acc1, Acc2}) ->
-            {Pid, MemVal, Call = [IsName | _]} = lists:nth(Pos, MemoryList),
-            [{_, Reductions}, {_, MsgQueueLen}] = get_reductions_and_msg_queue_len(Pid),
-            {CurFun, InitialCall} = get_current_initial_call(Call),
-            NameOrCall = display_name_or_initial_call(IsName, InitialCall),
-            Format = get_choose_format(RankPos, Pos),
+            {Pid, MemVal, CurFun, NameOrCall} = get_top_n_info(Pos, MemoryList),
+            {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
+            Format = get_top_n_format(RankPos, Pos),
             R = io_lib:format(Format,
-                [observer_cli_lib:to_list(Pos), pid_to_list(Pid), observer_cli_lib:byte_to_str(MemVal), NameOrCall,
-                    observer_cli_lib:to_list(Reductions), observer_cli_lib:to_list(MsgQueueLen), CurFun]),
+                [
+                    Pos, pid_to_list(Pid),
+                    observer_cli_lib:to_byte(MemVal), NameOrCall,
+                    observer_cli_lib:to_list(Reductions),
+                    observer_cli_lib:to_list(MsgQueueLen), CurFun
+                ]),
             {[R | Acc1], [{Pos, Pid} | Acc2]}
                     end, {[], []}, lists:seq(1, erlang:min(Num, erlang:length(MemoryList)))),
     {ProcList, [Title | Rows]};
-render_process_rank(reductions, ReductionList, Num, RankPos) ->
+render_top_n_view(reductions, ReductionList, Num, RankPos) ->
     Title = ?render([
-        ?W("Pid", 15), ?W(?RED, "Reductions", 11),
-        ?W("Name or Initial Call", 30),
+        ?W("Pid", 15), ?W(?RED, "Reductions", 11), ?W("Name or Initial Call", 30),
         ?W("Memory", 10), ?W("Msg Queue", 10), ?W("Current Function", 47),
         ?RESET]),
     {Rows, ProcList} =
         lists:foldr(fun(Pos, {Acc1, Acc2}) ->
-            {Pid, Reductions, Call = [IsName | _]} = lists:nth(Pos, ReductionList),
-            [{_, Memory}, {_, MsgQueueLen}] = get_memory_and_msg_queue_len(Pid),
-            {CurFun, InitialCall} = get_current_initial_call(Call),
-            NameOrCall = display_name_or_initial_call(IsName, InitialCall),
-            Format = get_choose_format(RankPos, Pos),
+            {Pid, Reductions, CurFun, NameOrCall} = get_top_n_info(Pos, ReductionList),
+            {Memory, MsgQueueLen} = get_pid_info(Pid, [memory, message_queue_len]),
+            Format = get_top_n_format(RankPos, Pos),
             R = io_lib:format(Format,
-                [observer_cli_lib:to_list(Pos), pid_to_list(Pid), observer_cli_lib:to_list(Reductions), NameOrCall,
-                    observer_cli_lib:byte_to_str(Memory), observer_cli_lib:to_list(MsgQueueLen), CurFun]),
+                [
+                    Pos, pid_to_list(Pid),
+                    observer_cli_lib:to_list(Reductions), NameOrCall,
+                    observer_cli_lib:to_byte(Memory),
+                    observer_cli_lib:to_list(MsgQueueLen), CurFun
+                ]),
             {[R | Acc1], [{Pos, Pid} | Acc2]}
                     end, {[], []}, lists:seq(1, erlang:min(Num, erlang:length(ReductionList)))),
     {ProcList, [Title | Rows]};
-render_process_rank(total_heap_size, HeapList, Num, RankPos) ->
+render_top_n_view(total_heap_size, HeapList, Num, RankPos) ->
     Title = ?render([
         ?W("Pid", 15), ?W(?RED, "TotalHeap", 11),
         ?W("Name or Initial Call", 30),
@@ -320,33 +318,36 @@ render_process_rank(total_heap_size, HeapList, Num, RankPos) ->
         ?RESET]),
     {Rows, ProcList} =
         lists:foldr(fun(Pos, {Acc1, Acc2}) ->
-            {Pid, HeapSize, Call = [IsName | _]} = lists:nth(Pos, HeapList),
-            [{_, Reductions}, {_, MsgQueueLen}] = get_reductions_and_msg_queue_len(Pid),
-            {CurFun, InitialCall} = get_current_initial_call(Call),
-            NameOrCall = display_name_or_initial_call(IsName, InitialCall),
-            Format = get_choose_format(RankPos, Pos),
+            {Pid, HeapSize, CurFun, NameOrCall} = get_top_n_info(Pos, HeapList),
+            {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
+            Format = get_top_n_format(RankPos, Pos),
             R = io_lib:format(Format,
-                [observer_cli_lib:to_list(Pos), pid_to_list(Pid), observer_cli_lib:byte_to_str(HeapSize), NameOrCall,
-                    observer_cli_lib:to_list(Reductions), observer_cli_lib:to_list(MsgQueueLen), CurFun]),
+                [
+                    Pos, pid_to_list(Pid),
+                    observer_cli_lib:to_byte(HeapSize), NameOrCall,
+                    observer_cli_lib:to_list(Reductions),
+                    observer_cli_lib:to_list(MsgQueueLen), CurFun
+                ]),
             {[R | Acc1], [{Pos, Pid} | Acc2]}
                     end, {[], []}, lists:seq(1, erlang:min(Num, erlang:length(HeapList)))),
     {ProcList, [Title | Rows]};
-render_process_rank(message_queue_len, MQLenList, Num, RankPos) ->
+render_top_n_view(message_queue_len, MQLenList, Num, RankPos) ->
     Title = ?render([
-        ?W("Pid", 15), ?W(?RED, "Msg Queue", 11),
-        ?W("Name or Initial Call", 30),
+        ?W("Pid", 15), ?W(?RED, "Msg Queue", 11), ?W("Name or Initial Call", 30),
         ?W("Memory", 10), ?W("Reductions", 10), ?W("Current Function", 47),
         ?RESET]),
     {Rows, ProcList} =
         lists:foldr(fun(Pos, {Acc1, Acc2}) ->
-            {Pid, MQLen, Call = [IsName | _]} = lists:nth(Pos, MQLenList),
-            [{_, Reductions}, {_, Memory}] = get_reductions_and_memory(Pid),
-            {CurFun, InitialCall} = get_current_initial_call(Call),
-            NameOrCall = display_name_or_initial_call(IsName, InitialCall),
-            Format = get_choose_format(RankPos, Pos),
+            {Pid, MQLen, CurFun, NameOrCall} = get_top_n_info(Pos, MQLenList),
+            {Reductions, Memory} = get_pid_info(Pid, [reductions, memory]),
+            Format = get_top_n_format(RankPos, Pos),
             R = io_lib:format(Format,
-                [observer_cli_lib:to_list(Pos), pid_to_list(Pid), observer_cli_lib:to_list(MQLen), NameOrCall,
-                    observer_cli_lib:byte_to_str(Memory), observer_cli_lib:to_list(Reductions), CurFun]),
+                [
+                    Pos, pid_to_list(Pid),
+                    observer_cli_lib:to_list(MQLen), NameOrCall,
+                    observer_cli_lib:to_byte(Memory),
+                    observer_cli_lib:to_list(Reductions), CurFun
+                ]),
             {[R | Acc1], [{Pos, Pid} | Acc2]}
                     end, {[], []}, lists:seq(1, erlang:min(Num, erlang:length(MQLenList)))),
     {ProcList, [Title | Rows]}.
@@ -360,14 +361,14 @@ render_last_line() ->
 notify_pause_status() ->
     ?output("\e[31;1m PAUSE  INPUT (p, r/rr, b/bb, h/hh, m/mm) to resume or q to quit \e[0m~n").
 
-get_choose_format(Pos, Pos) ->
-    "|\e[33m~-3.3s|~-12.12s|~12.12s | ~-30.30s | ~11.11s| ~-11.11s| ~-47.47s\e[0m|~n";
-get_choose_format(_Pos, _RankPos) ->
-    "|~-3.3s|~-12.12s|~12.12s | ~-30.30s | ~11.11s| ~-11.11s| ~-47.47s|~n".
+get_top_n_format(Pos, Pos) ->
+    "|\e[33m~-3.3w|~-12.12s|~12.12s | ~-30.30s | ~11.11s| ~-11.11s| ~-47.47s\e[0m|~n";
+get_top_n_format(_Pos, _RankPos) ->
+    "|~-3.3w|~-12.12s|~12.12s | ~-30.30s | ~11.11s| ~-11.11s| ~-47.47s|~n".
 
-refresh_next_time(proc_count, Type, Interval, RankCostTime, NodeStatsCostTime) ->
-    erlang:send_after(Interval - RankCostTime - NodeStatsCostTime, self(), {proc_count, Type});
-refresh_next_time(proc_window, Type, _Interval, _RankCostTime, _CollectTime) ->
+refresh_next_time(proc_count, Type, Interval) ->
+    erlang:send_after(Interval, self(), {proc_count, Type});
+refresh_next_time(proc_window, Type, _Interval) ->
     erlang:send_after(100, self(), {proc_window, Type}).
 
 get_current_initial_call(Call) ->
@@ -375,7 +376,7 @@ get_current_initial_call(Call) ->
     {_, InitialCall} = lists:keyfind(initial_call, 1, Call),
     {observer_cli_lib:mfa_to_list(CurFun), observer_cli_lib:mfa_to_list(InitialCall)}.
 
-get_port_proc_count_info(PortLimit, ProcLimit, ProcSum) ->
+get_port_proc_info(PortLimit, ProcLimit, ProcSum) ->
     ProcCountInt = proplists:get_value(process_count, ProcSum),
     PortLimitInt = list_to_integer(PortLimit),
     ProcLimitInt = list_to_integer(ProcLimit),
@@ -396,7 +397,7 @@ get_port_proc_count_info(PortLimit, ProcLimit, ProcSum) ->
         end,
     {PortWarning, ProcWarning, PortCount, ProcCount}.
 
-cpu_format_alarm_color(Percent1, Percent2) ->
+process_bar_format_style(Percent1, Percent2, IsLastLine) ->
     Warning1 =
         case Percent1 >= ?CPU_ALARM_THRESHOLD of
             true -> ?RED;
@@ -407,9 +408,13 @@ cpu_format_alarm_color(Percent1, Percent2) ->
             true -> ?RED;
             false -> ?GREEN
         end,
-    <<"|", Warning1/binary, "|~-2.2s ~-57.57s", "~s", Warning2/binary, " |~-2.2s ~-57.57s", " ~s", "  |~n">>.
+    Format = <<"|", Warning1/binary, "|~2..0w ~-57.57s", "~s", Warning2/binary, " |~2..0w ~-57.57s", " ~s", "  |~n">>,
+    case IsLastLine of
+        true -> <<?UNDERLINE/binary, Format/binary, ?RESET/binary>>;
+        false -> Format
+    end.
 
-cpu_format_alarm_color(Percent1, Percent2, Percent3, Percent4) ->
+process_bar_format_style(Percent1, Percent2, Percent3, Percent4, IsLastLine) ->
     Warning1 =
         case Percent1 >= ?CPU_ALARM_THRESHOLD of
             true -> ?RED;
@@ -430,57 +435,55 @@ cpu_format_alarm_color(Percent1, Percent2, Percent3, Percent4) ->
             true -> ?RED;
             false -> ?GREEN
         end,
-    <<"|",
-        Warning1/binary, "|~-2.2s ~-23.23s", " ~s",
-        Warning2/binary, " |~-2.2s ~-22.22s", " ~s",
-        Warning3/binary, " |~-2.2s ~-22.22s", " ~s",
-        Warning4/binary, " |~-2.2s ~-23.23s", " ~s",
-        " |~n">>.
+    Format =
+        <<"|",
+            Warning1/binary, "|~-2.2w ~-23.23s", " ~s",
+            Warning2/binary, " |~-2.2w ~-22.22s", " ~s",
+            Warning3/binary, " |~-2.2w ~-22.22s", " ~s",
+            Warning4/binary, " |~-2.2w ~-23.23s", " ~s",
+            " |~n">>,
+    case IsLastLine of
+        true -> <<?UNDERLINE/binary, Format/binary, ?RESET/binary>>;
+        false -> Format
+    end.
+
+get_top_n_info(Pos, List) ->
+    {Pid, Val, Call = [IsName | _]} = lists:nth(Pos, List),
+    {CurFun, InitialCall} = get_current_initial_call(Call),
+    NameOrCall = display_name_or_initial_call(IsName, InitialCall),
+    {Pid, Val, CurFun, NameOrCall}.
 
 display_name_or_initial_call(IsName, _Call) when is_atom(IsName) -> atom_to_list(IsName);
 display_name_or_initial_call(_IsName, Call) -> Call.
 
-get_refresh_cost_info(proc_count, Type, Interval, Rows) ->
-    io_lib:format("recon:proc_count(~p,~w) Interval:~wms", [Type, Rows, Interval]);
-get_refresh_cost_info(proc_window, Type, Interval, Rows) ->
-    io_lib:format("recon:proc_window(~p,~w,~w) Interval:~wms", [Type, Rows, Interval * 2 - Interval div 2, Interval * 2]).
+get_refresh_prompt(proc_count, Type, Interval, Rows) ->
+    io_lib:format("recon:proc_count(~p, ~w) Interval:~wms", [Type, Rows, Interval]);
+get_refresh_prompt(proc_window, Type, Interval, Rows) ->
+    io_lib:format("recon:proc_window(~p, ~w, ~w) Interval:~wms", [Type, Rows, Interval, Interval]).
 
 
 get_stable_system_info() ->
-    [begin observer_cli_lib:to_list(erlang:system_info(Item)) end || Item <- ?STABLE_SYSTEM_ITEM].
+    [begin observer_cli_lib:to_list(erlang:system_info(Item)) end || Item <- ?STABLE_SYSTEM_KEY].
 
 get_change_system_info() ->
     UsedMem = recon_alloc:memory(used),
     AllocatedMem = recon_alloc:memory(allocated),
-    [UsedMem, AllocatedMem, AllocatedMem - UsedMem].
+    {UsedMem, AllocatedMem, AllocatedMem - UsedMem}.
 
-get_reductions_and_msg_queue_len(Pid) ->
-    case recon:info(Pid, [reductions, message_queue_len]) of
-        undefined -> [{reductions, "die"}, {message_queue_len, "die"}];
-        Info -> Info
+get_pid_info(Pid, Keys) ->
+    case recon:info(Pid, Keys) of
+        undefined -> {"die", "die"};
+        [{_, Val1}, {_, Val2}] -> {Val1, Val2}
     end.
 
-get_memory_and_msg_queue_len(Pid) ->
-    case recon:info(Pid, [memory, message_queue_len]) of
-        undefined -> [{memory, "die"}, {message_queue_len, "die"}];
-        Info -> Info
-    end.
-
-get_reductions_and_memory(Pid) ->
-    case recon:info(Pid, [reductions, memory]) of
-        undefined -> [{reductions, "die"}, {memory, "die"}];
-        Info -> Info
-    end.
-
-get_ranklist_and_cost_time(proc_window, Type, Interval, Rows, Time) when Time =/= ?FAST_COLLECT_INTERVAL ->
-    RemainTime = 2 * Interval - Time,
-    {recon:proc_window(Type, Rows, RemainTime), RemainTime};
-get_ranklist_and_cost_time(_, Type, _Interval, Rows, _CollectTime) ->
-    {recon:proc_count(Type, Rows), 0}.
+get_top_n(proc_window, Type, Interval, Rows, IsFirstTime)when not IsFirstTime ->
+    recon:proc_window(Type, Rows, Interval);
+get_top_n(_Func, Type, _Interval, Rows, _FirstTime) ->
+    recon:proc_count(Type, Rows).
 
 connect_error(Prompt, Node) ->
     Prop = <<?RED/binary, Prompt/binary, ?RESET/binary>>,
-    ?output(Prop, [Node, erlang:get_cookie()]).
+    ?output(Prop, [Node]).
 
 start_process_view(Tid, Pos, ChildPid, Opts) ->
     case ets:lookup(Tid, Pos) of
@@ -489,4 +492,10 @@ start_process_view(Tid, Pos, ChildPid, Opts) ->
             erlang:exit(ChildPid, stop),
             NewHomeOpt = Opts#view_opts.home#home{cur_pos = Pos},
             observer_cli_process:start(ChoosePid, Opts#view_opts{home = NewHomeOpt})
+    end.
+
+check_auto_row() ->
+    case io:rows() of
+        {ok, _} -> true;
+        {error, _} -> false
     end.

--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -133,7 +133,7 @@ render_system_line(StableInfo, UseMemInt, AllocatedMemInt, UnusedMemInt, ProcSum
     Title = ?render([?GRAY_BG,
         ?W("System", 10), ?W("Count/Limit", 21),
         ?W("System Switch", 20), ?W("State", 24),
-        ?W("Memory Info", 20), ?W("Megabyte", 28),
+        ?W("Memory Info", 20), ?W("Size", 28),
         ?RESET]),
     Row1 = ?render([
         ?W("Proc Count", 10), ?W(ProcWarning, ProcCount, 21), ?W("Smp Support", 20),
@@ -174,8 +174,8 @@ render_memory_process_line(ProcSum, MemSum, Interval) ->
     GcWordsReclaimed = observer_cli_lib:to_list(proplists:get_value(gc_words_reclaimed, MemSum)),
     Reductions = integer_to_list(proplists:get_value(reductions, MemSum)),
     Row1 = ?render([
-        ?GRAY_BG, ?W("Memory", 10), ?W("State", 21), ?W("Memory", 20), ?W("State", 24),
-        ?W("Memory", 20), ?W("Interval: " ++ integer_to_list(Interval) ++ "ms", 28), ?RESET]),
+        ?GRAY_BG, ?W("Memory", 10), ?W("Size", 21), ?W("Memory", 20), ?W("Size", 24),
+        ?W("IO/GC", 20), ?W("Interval: " ++ integer_to_list(Interval) ++ "ms", 28), ?RESET]),
     Row2 = ?render([
         ?W("Total", 10), ?W(TotalMem, 12), ?W("100%", 6), ?W("Binary", 20),
         ?W(BinMem, 15), ?W(BinMemPercent, 6), ?W("IO Output", 20), ?W(BytesOut, 28)]),

--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -174,7 +174,7 @@ render_memory_process_line(ProcSum, MemSum, Interval) ->
     Row1 = ?render([
         ?GRAY_BG, ?W("Mem Type", 10), ?W("Size", 21),
         ?W("Mem Type", 25), ?W("Size", 21),
-        ?W("IO/GC", 20), ?W(["Interval: ", integer_to_binary(Interval), "ms"], 26),
+        ?W("IO/GC", 20), ?W(["Interval: ", erlang:integer_to_binary(Interval), "ms"], 26),
         ?RESET]),
     Row2 = ?render([
         ?W("Total", 10), ?W({byte, TotalMem}, 12), ?W("100.0%", 6),

--- a/src/observer_cli_allocator.erl
+++ b/src/observer_cli_allocator.erl
@@ -62,7 +62,7 @@ render_cache_hit_rates(CacheHitInfo) ->
     Len = erlang:length(CacheHitInfo),
     View = [begin
          [{hit_rate, HitRate}, {hits, Hit}, {calls, Call}] = proplists:get_value({instance, Seq}, CacheHitInfo),
-         HitRateStr = observer_cli_lib:float_to_percent_with_two_digit(HitRate),
+         HitRateStr = observer_cli_lib:to_percent(HitRate),
          SeqStr = lists:flatten(io_lib:format("~2..0w", [Seq])),
          TrueHitRate = case Hit == 0 andalso Call == 0 of true -> 0; false -> HitRate end,
          Process = lists:duplicate(trunc(TrueHitRate * 91), "|"),
@@ -99,7 +99,7 @@ get_alloc(Key, Curs, Maxes) ->
     MaxMbcs = proplists:get_value(mbcs, MaxRes),
     MaxSbcs = proplists:get_value(sbcs, MaxRes),
     [atom_to_list(Key),
-        observer_cli_lib:byte_to_str(CurMbcs),
-        observer_cli_lib:byte_to_str(MaxMbcs),
-        observer_cli_lib:byte_to_str(CurSbcs),
-        observer_cli_lib:byte_to_str(MaxSbcs)].
+        observer_cli_lib:to_byte(CurMbcs),
+        observer_cli_lib:to_byte(MaxMbcs),
+        observer_cli_lib:to_byte(CurSbcs),
+        observer_cli_lib:to_byte(MaxSbcs)].

--- a/src/observer_cli_inet.erl
+++ b/src/observer_cli_inet.erl
@@ -9,10 +9,10 @@
 
 -spec start(view_opts()) -> no_return.
 start(#view_opts{inet = #inet{interval = Interval, func = Function, type = Type},
-    terminal_row = TerminalRow} = ViewOpts) ->
+    auto_row = AutoRow} = ViewOpts) ->
     Pid = spawn(fun() ->
         ?output(?CLEAR),
-        render_worker(Function, Type, Interval, undefined, 0, TerminalRow)
+        render_worker(Function, Type, Interval, undefined, 0, AutoRow)
                 end),
     manager(Pid, ViewOpts).
 
@@ -36,8 +36,8 @@ manager(ChildPid, ViewOpts = #view_opts{inet = InetOpts}) ->
         _ -> manager(ChildPid, ViewOpts)
     end.
 
-render_worker(Function, Type, Interval, LastTimeRef, Count, TerminalRow0) ->
-    TerminalRow = observer_cli_lib:to_row(TerminalRow0),
+render_worker(Function, Type, Interval, LastTimeRef, Count, AutoRow) ->
+    TerminalRow = observer_cli_lib:get_terminal_rows(AutoRow),
     Rows = TerminalRow - 4,
     Text = get_refresh_str(Function, Type, Interval, Rows),
     Menu = observer_cli_lib:render_menu(inet, Text, 133),
@@ -51,8 +51,8 @@ render_worker(Function, Type, Interval, LastTimeRef, Count, TerminalRow0) ->
         quit -> quit;
         {new_interval, NewInterval} ->
             ?output(?CLEAR),
-            render_worker(Function, Type, NewInterval, TimeRef, Count + 1, TerminalRow0);
-        _ -> render_worker(Function, Type, Interval, TimeRef, Count + 1, TerminalRow0)
+            render_worker(Function, Type, NewInterval, TimeRef, Count + 1, AutoRow);
+        _ -> render_worker(Function, Type, Interval, TimeRef, Count + 1, AutoRow)
     end.
 
 render_inet_rows([], Type, inet_count, _Interval, Rows) ->
@@ -100,9 +100,9 @@ render_last_line(Interval) ->
         ?W(Text, ?COLUMN - 11), ?RESET]).
 
 get_refresh_str(inet_count, Type, Interval, Rows) ->
-    io_lib:format("recon:inet_count(~p,~w) Interval:~wms", [Type, Rows, Interval]);
+    io_lib:format("recon:inet_count(~p, ~w) Interval:~wms", [Type, Rows, Interval]);
 get_refresh_str(inet_window, Type, Interval, Rows) ->
-    io_lib:format("recon:inet_window(~p,~w,~w) Interval:~wms", [Type, Rows, Interval, Interval]).
+    io_lib:format("recon:inet_window(~p, ~w, ~w) Interval:~wms", [Type, Rows, Interval, Interval]).
 
 inet_info(inet_count, Type, Num, _, _) -> recon:inet_count(Type, Num);
 inet_info(inet_window, Type, Num, _, 0) -> recon:inet_count(Type, Num);

--- a/src/observer_cli_mnesia.erl
+++ b/src/observer_cli_mnesia.erl
@@ -8,18 +8,18 @@
 
 -spec start(#view_opts{}) -> any().
 
-start(#view_opts{db = #db{interval = MillSecond}, terminal_row = TerminalRow} = HomeOpts) ->
+start(#view_opts{db = #db{interval = MillSecond}, auto_row = AutoRow} = HomeOpts) ->
     Pid = spawn(fun() ->
         ?output(?CLEAR),
-        render_worker(MillSecond, undefined, true, TerminalRow)
+        render_worker(MillSecond, undefined, true, AutoRow)
                 end),
     manager(Pid, HomeOpts).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Private
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-render_worker(Interval, LastTimeRef, HideSystemTable, TerminalRow0) ->
-    TerminalRow = observer_cli_lib:to_row(TerminalRow0),
+render_worker(Interval, LastTimeRef, HideSystemTable, AutoRow) ->
+    TerminalRow = observer_cli_lib:get_terminal_rows(AutoRow),
     Rows = TerminalRow - 5,
     Text = "Interval: " ++ integer_to_list(Interval) ++ "ms"
         ++ " HideSystemTable:" ++ atom_to_list(HideSystemTable),
@@ -36,9 +36,9 @@ render_worker(Interval, LastTimeRef, HideSystemTable, TerminalRow0) ->
     TimeRef = observer_cli_lib:next_redraw(LastTimeRef, Interval),
     receive
         quit -> quit;
-        {new_interval, NewInterval} -> render_worker(NewInterval, TimeRef, HideSystemTable, TerminalRow0);
-        {system_table, NewHideSystemTable} -> render_worker(Interval, TimeRef, NewHideSystemTable, TerminalRow0);
-        _ -> render_worker(Interval, TimeRef, HideSystemTable, TerminalRow0)
+        {new_interval, NewInterval} -> render_worker(NewInterval, TimeRef, HideSystemTable, AutoRow);
+        {system_table, NewHideSystemTable} -> render_worker(Interval, TimeRef, NewHideSystemTable, AutoRow);
+        _ -> render_worker(Interval, TimeRef, HideSystemTable, AutoRow)
     end.
 
 manager(ChildPid, #view_opts{db = DBOpts} = HomeOpts) ->


### PR DESCRIPTION
1. Change `#view_opt.terminal_row::integer`  to `auto_row::boolean`. 
2. More clear prompt when can't connect remote node. 
3. Make compute top_n(`recon:proc_count/2 recon:proc_window/3`) refresh time more simple. 
4. Add `error_logger_queue` in Home view to show `error_logger` message length.
 5. change `B K M G` to `B KB MB GB`
6. `?W/2` can accept integer, make code more clean.