### PR TITLE
No need to add to extra applications in mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ dep_observer_cli = hex 1.3.1
 ```elixir
 # mix.exs                                                                                                   
    def deps do                                                          
-     [{:observer_cli, "~> 1.3.1"}]
+     [{:observer_cli, "~> 1.3"}]
    end
-   def application do
-     [extra_applications: [:observer_cli]]
-  end
 ```  
 ------------------
 ### How-To


### PR DESCRIPTION
extra applications is only useful for things that are part of the OTP or Elixir releases. Packages are tracked automatically from deps.

Also, in mix the preferred way to specify dependencies is with `~> major.minor` which should allow updating minor versions - those should be backwards compatible. Accidental updates are not a concern due to lockfiles.