### PR TITLE
Allow to compile escript w/ inet6 based distribution

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,3 +25,9 @@
 {xref_checks, [undefined_function_calls]}.
 {cover_enabled, true}.
 {post_hooks, [{"(linux|darwin|solaris)", edoc, "escript doc/docsite.erl"}]}.
+
+{profiles, [
+  {inet6, [
+    {escript_emu_args, "%%! -escript main observer_cli_escriptize -hidden -proto_dist inet6_tcp +sbtu +A0 -elixir ansi_enabled true\n"}
+  ]}
+]}.


### PR DESCRIPTION
This will make possible to deploy and use escript in an IPv6-only environment.