### PR TITLE
Recon 2.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ObserverCli.MixProject do
   def project do
     [
       app: :observer_cli,
-      version: "1.4.4",
+      version: "1.4.5",
       language: :erlang,
       start_permanent: Mix.env == :prod,
       deps: []

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,9 @@ defmodule ObserverCli.MixProject do
       version: "1.4.5",
       language: :erlang,
       start_permanent: Mix.env == :prod,
-      deps: []
+      deps: [
+        {:recon, "~> 2.5.0"},
+      ]
     ]
   end
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
-[{<<"recon">>,{pkg,<<"recon">>,<<"2.4.0">>},0}]}.
+[{<<"recon">>,{pkg,<<"recon">>,<<"2.5.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"recon">>, <<"901FF78B39C754FB4D6FD72DCF0DBD398967BBD2E4D59C08D4D7AA44A73DE91D">>}]}
+ {<<"recon">>, <<"2F7FCBEC2C35034BADE2F9717F77059DC54EB4E929A3049CA7BA6775C0BD66CD">>}]}
 ].


### PR DESCRIPTION
Recon 2.5.0 comes with [support for Erlang 22](https://github.com/ferd/recon/pull/73).