### PR TITLE
Fix error when inspecting process that monitors via {RegName, Node}

### DIFF
--- a/src/observer_cli_process.erl
+++ b/src/observer_cli_process.erl
@@ -284,10 +284,10 @@ render_link_monitor(Link, Monitors, MonitoredBy) ->
     MonitorsStr = [
         begin
             case P of
+                {process, {RegName, Node}} ->
+                    observer_cli_lib:to_list(RegName) ++ "/" ++ observer_cli_lib:to_list(Node);
                 {process, Pid} ->
-                    observer_cli_lib:to_list(Pid);
-                {RegName, Node} ->
-                    observer_cli_lib:to_list(RegName) ++ "/" ++ observer_cli_lib:to_list(Node)
+                    observer_cli_lib:to_list(Pid)
             end
         end
         || P <- lists:sublist(Monitors, 30)


### PR DESCRIPTION
Before this commit, when getting the process info in the observer CLI of a
worker process that monitors another process via
```
erlang:monitor(process, {registered_name(), node()})
```
the CLI crashed with the following error:
```
07:52:16.293 [error] Process #PID<11118.11514.13> on node :rabbit@me raised an exception
** (ArgumentError) argument error
    (stdlib 3.17) io_lib.erl:187: :io_lib.format("|~-16.16ts | ~-112.112ts | \e[0m\n|~-16.16ts | ~-112.112ts | \e[0m\n|~-16.16ts | ~-112.112ts \e[0m|~n", ['Links(1)', ['<0.522.0>'], 'Monitors(1)', ["%2F_qq-10": :rabbit@me], 'MonitoredBy(1)', ['<0.529.0>']])
    src/observer_cli_process.erl:90: :observer_cli_process.render_worker/7
```
Note than `recon:info(Pid)` returns
```
...
{signals,[{links,[<0.691.0>]},
           {monitors,[{process,{'%2F_qq-10','rabbit@me'}}]},
           {monitored_by,[]},
           {trap_exit,false}]},
...
```

Also see https://github.com/erlang/otp/blob/e5241e4b777b77db51ec83855958e67420048d94/erts/preloaded/src/erlang.erl#L2521-L2523 for latest Erlang master branch.

After this commit, observer CLI does not crash anymore.
Tested on Erlang 24.2.1.

Thanks @mkuratczyk for spotting the bug.