### PR TITLE
Add `pid<1.2.3>` command

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{
-  "recon": {:hex, :recon, "2.5.1", "430ffa60685ac1efdfb1fe4c97b8767c92d0d92e6e7c3e8621559ba77598678a", [:mix, :rebar3], [], "hexpm"},
+  "recon": {:hex, :recon, "2.5.1", "430ffa60685ac1efdfb1fe4c97b8767c92d0d92e6e7c3e8621559ba77598678a", [:mix, :rebar3], [], "hexpm", "5721c6b6d50122d8f68cccac712caa1231f97894bab779eff5ff0f886cb44648"},
 }

--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -138,6 +138,10 @@ manager(StorePid, RenderPid, Opts, LastSchWallFlag) ->
             NewPages = observer_cli_lib:update_page_pos(StorePid, NewPage, Pages),
             clean(Resource),
             start(Opts#view_opts{home = Home#home{cur_page = NewPage, pages = NewPages}});
+        {go_to_pid, PidStr} ->
+            Pid = erlang:list_to_pid(PidStr),
+            clean(Resource),
+            observer_cli_process:start(home, Pid, Opts);
         _ ->
             manager(StorePid, RenderPid, Opts, LastSchWallFlag)
     end.

--- a/src/observer_cli_lib.erl
+++ b/src/observer_cli_lib.erl
@@ -362,6 +362,9 @@ parse_cmd(ViewOpts, Module, Args) ->
             hide;
         "`\n" ->
             scheduler_usage;
+        [$p, $i, $d | PidStr] ->
+            NoNewline = lists:reverse(tl(lists:reverse(PidStr))),
+            {go_to_pid, NoNewline};
         %% {error, estale}|{error, terminated}
         {error, _Reason} ->
             quit;


### PR DESCRIPTION
This PR addresses the request from issue #85. To jump to a PID, type `pid<1.2.3>` in the console