### PR TITLE
fix: Add ending separator to the menu options

### DIFF
--- a/src/observer_cli_lib.erl
+++ b/src/observer_cli_lib.erl
@@ -27,9 +27,6 @@
 -export([sublist/3]).
 -export([sbcs_to_mbcs/2]).
 
--define(select(Title), ?RED_BG, Title, ?RESET_BG).
--define(unselect(Title), ?L_GRAY_BG, Title, ?RESET_BG).
-
 -spec uptime() -> list().
 uptime() ->
     {UpTime, _} = erlang:statistics(wall_clock),
@@ -54,125 +51,19 @@ to_list(Ref) when is_reference(Ref) -> erlang:ref_to_list(Ref);
 to_list(Float) when is_float(Float) -> erlang:float_to_list(Float, [{decimals, 4}]);
 to_list(Val) -> Val.
 
-get_menu_title(home, MnesiaTitle) ->
-    [
-        ?select("Home(H)"),
-        "|",
-        ?unselect("Network(N)"),
-        "|",
-        ?unselect("System(S)"),
-        "|",
-        ?unselect("Ets(E)"),
-        unselect(MnesiaTitle),
-        "|",
-        ?unselect("App(A)"),
-        "|",
-        ?unselect("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ];
-get_menu_title(ets, MnesiaTitle) ->
-    [
-        ?unselect("Home(H)"),
-        "|",
-        ?unselect("Network(N)"),
-        "|",
-        ?unselect("System(S)"),
-        "|",
-        ?select("Ets(E)"),
-        unselect(MnesiaTitle),
-        "|",
-        ?unselect("App(A)"),
-        "|",
-        ?unselect("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ];
-get_menu_title(allocator, MnesiaTitle) ->
-    [
-        ?unselect("Home(H)"),
-        "|",
-        ?unselect("Network(N)"),
-        "|",
-        ?select("System(S)"),
-        "|",
-        ?unselect("Ets(E)"),
-        unselect(MnesiaTitle),
-        "|",
-        ?unselect("App(A)"),
-        "|",
-        ?unselect("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ];
-get_menu_title(doc, MnesiaTitle) ->
-    [
-        ?unselect("Home(H)"),
-        "|",
-        ?unselect("Network(N)"),
-        "|",
-        ?unselect("System(S)"),
-        "|",
-        ?unselect("Ets(E)"),
-        unselect(MnesiaTitle),
-        "|",
-        ?unselect("App(A)"),
-        "|",
-        ?select("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ];
-get_menu_title(inet, MnesiaTitle) ->
-    [
-        ?unselect("Home(H)"),
-        "|",
-        ?select("Network(N)"),
-        "|",
-        ?unselect("System(S)"),
-        "|",
-        ?unselect("Ets(E)"),
-        unselect(MnesiaTitle),
-        "|",
-        ?unselect("App(A)"),
-        "|",
-        ?unselect("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ];
-get_menu_title(mnesia, MnesiaTitle) ->
-    [
-        ?unselect("Home(H)"),
-        "|",
-        ?unselect("Network(N)"),
-        "|",
-        ?unselect("System(S)"),
-        "|",
-        ?unselect("Ets(E)"),
-        select(MnesiaTitle),
-        "|",
-        ?unselect("App(A)"),
-        "|",
-        ?unselect("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ];
-get_menu_title(app, MnesiaTitle) ->
-    [
-        ?unselect("Home(H)"),
-        "|",
-        ?unselect("Network(N)"),
-        "|",
-        ?unselect("System(S)"),
-        "|",
-        ?unselect("Ets(E)"),
-        unselect(MnesiaTitle),
-        "|",
-        ?select("App(A)"),
-        "|",
-        ?unselect("Doc(D)"),
-        "|",
-        ?unselect("Plugin(P)")
-    ].
+get_menu_title(Selection, MnesiaTitle) ->
+    Options = [{home, "Home(H)"},
+               {inet, "Network(N)"},
+               {allocator, "System(S)"},
+               {ets, "Ets(E)"},
+               {mnesia, MnesiaTitle},
+               {app, "App(A)"},
+               {doc, "Doc(D)"},
+               {plugin, "Plugin(P)"}],
+    lists:map(fun({_Key, ""}) -> unselect("");
+                 ({Key, Value}) when Key =:= Selection -> select(Value) ++ "|";
+                 ({_Key, Value}) -> unselect(Value) ++ "|"
+              end, Options).
 
 -spec select(string()) -> list().
 select(Title) -> [?RED_BG, Title, ?RESET_BG].


### PR DESCRIPTION
Before this PR:
```
|Home(H)|Network(N)|System(S)|Ets(E)|App(A)|Doc(D)|Plugin(P)Interval: 2000ms
```
<img width="1389" alt="plugin-bar-before" src="https://github.com/zhongwencool/observer_cli/assets/1556349/ae3bafcf-efc4-440c-a539-50a9e6a47a07">

After this PR:
```
|Home(H)|Network(N)|System(S)|Ets(E)|App(A)|Doc(D)|Plugin(P)|Interval: 2000ms
```
<img width="1402" alt="plugin-bar-after" src="https://github.com/zhongwencool/observer_cli/assets/1556349/26460dab-e668-491e-a235-46400ce38d24">

Also reworked the get_menu_title/2 function so it's easier to change, and fixed a minor issue where pressing the Ets menu button didn't highlight the bar as in the other cases.