### PR TITLE
Fix unit of fullsweep_after

### DIFF
--- a/src/observer_cli_process.erl
+++ b/src/observer_cli_process.erl
@@ -271,7 +271,7 @@ render_process_info(
             ?W("total_heap_size", 16),
             ?W({byte, TotalHeapSize}, 12),
             ?W("fullsweep_after", 18),
-            ?W({byte, FullSweepAfter}, 12),
+            ?W(FullSweepAfter, 12),
             ?NEW_LINE,
             ?W("status", 16),
             ?W(Status, 42),


### PR DESCRIPTION
The value of `fullsweep_after` is a number, not bytes. It's the count of how many minor GCs happen before forcing a full GC.

For reference, see https://www.erlang.org/docs/26/man/erlang

> Option `fullsweep_after` makes it possible to specify the maximum number of generational collections before forcing a fullsweep, even if there is room on the old heap. Setting the number to zero disables the general collection algorithm, that is, all live data is copied at every garbage collection.

