### PR TITLE
correct the units shown for memory data

### DIFF
--- a/src/observer_cli_lib.erl
+++ b/src/observer_cli_lib.erl
@@ -84,13 +84,13 @@ to_byte(Byte) when is_integer(Byte), Byte < 1024 ->
     [erlang:integer_to_list(Byte), $\s, $B];
 %% kilobyte
 to_byte(Byte) when Byte < 1024 * 1024 ->
-    [erlang:float_to_list(Byte / 1024, [{decimals, 4}]), $\s, $K, $B];
+    [erlang:float_to_list(Byte / 1024, [{decimals, 4}]), $\s, $K, $i, $B];
 %% megabyte
 to_byte(Byte) when Byte < 1024 * 1024 * 1024 ->
-    [erlang:float_to_list(Byte / (1024 * 1024), [{decimals, 4}]), $\s, $M, $B];
+    [erlang:float_to_list(Byte / (1024 * 1024), [{decimals, 4}]), $\s, $M, $i, $B];
 %% megabyte
 to_byte(Byte) when is_integer(Byte) ->
-    [erlang:float_to_list(Byte / (1024 * 1024 * 1024), [{decimals, 4}]), $\s, $G, $B];
+    [erlang:float_to_list(Byte / (1024 * 1024 * 1024), [{decimals, 4}]), $\s, $G, $i, $B];
 %% process died
 to_byte(Byte) ->
     [to_list(Byte)].


### PR DESCRIPTION
The units returned by `to_byte/1` are kilobytes (KB), megabytes (MB) and gigabytes (GB) but the actual numeric value are for kibibyte (KiB), mebibyte(MiB) and gibibyte(GiB). This is because the division is by 1024.

I found this problem when I was comparing the value agaist the output of rebar:info and didn't match.

I did a similar patch a few years ago on OTP's observer [1].

[1] https://github.com/erlang/otp/pull/6063