### PR TITLE
Fix compile warning on OTP 27

### DIFF
--- a/src/observer_cli_lib.erl
+++ b/src/observer_cli_lib.erl
@@ -35,11 +35,17 @@ uptime() ->
     [?W(?GREEN, Time, 16)].
 
 %% @doc 0.982342 -> 98.23%, 1 -> 100.0%
-to_percent(Float) when Float < 0.1 -> [$0, erlang:float_to_list(Float * 100, [{decimals, 2}]), $%];
-to_percent(Float) when Float < 1 -> [erlang:float_to_list(Float * 100, [{decimals, 2}]), $%];
-to_percent(undefined) -> "******";
-to_percent(_) -> "100.0%".
+-spec to_percent(term()) -> string().
+to_percent(Float) when is_float(Float), Float < 0.1 ->
+    [$0, erlang:float_to_list(Float * 100, [{decimals, 2}]), $%];
+to_percent(Float) when is_float(Float), Float < 1 ->
+    [erlang:float_to_list(Float * 100, [{decimals, 2}]), $%];
+to_percent(undefined) ->
+    "******";
+to_percent(_) ->
+    "100.0%".
 
+-spec to_list(term()) -> string().
 to_list(Atom) when is_atom(Atom) -> atom_to_list(Atom);
 to_list(Integer) when is_integer(Integer) -> integer_to_list(Integer);
 to_list(Pid) when is_pid(Pid) -> erlang:pid_to_list(Pid);


### PR DESCRIPTION
```
    ┌─ src/observer_cli_lib.erl:
    │
 38 │  to_percent(Float) when Float < 0.1 -> [$0, erlang:float_to_list(Float * 100, [{decimals, 2}]), $%];
    │  ╰── Warning: missing specification for function to_percent/1

    ┌─ src/observer_cli_lib.erl:
    │
 43 │  to_list(Atom) when is_atom(Atom) -> atom_to_list(Atom);
    │  ╰── Warning: missing specification for function to_list/1
```