### PR TITLE
Removed recon from included_applications

### DIFF
--- a/src/observer_cli.app.src
+++ b/src/observer_cli.app.src
@@ -5,9 +5,6 @@
         observer_cli
     ]},
     {registered, []},
-    {included_applications, [
-        recon
-    ]},
     {applications, [
         kernel,
         stdlib,


### PR DESCRIPTION
included_applications needed for loading and manual starting of otp-app. Recon - just a library.

Also this could break releases, that depends on recon.