### PR TITLE
Handle unchanged case in net_kernel:set_net_ticktime

### DIFF
--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -933,5 +933,7 @@ update_net_ticktime_from(Node) ->
         change_initiated ->
             ok;
         {ongoing_change_to, NetTickTime} ->
+            ok;
+        unchanged ->
             ok
     end.


### PR DESCRIPTION
Add `unchanged` as a valid option. 
You can check it is a valid response in https://www.erlang.org/doc/apps/kernel/net_kernel.html#set_net_ticktime/1