### PR TITLE
fix: Til names

### DIFF
--- a/include/observer_cli.hrl
+++ b/include/observer_cli.hrl
@@ -116,6 +116,6 @@
 
 -define('render'(_FA_), observer_cli_lib:render(_FA_)).
 -define('output'(_F_, _A_), io:format(iolist_to_binary(_F_), _A_)).
--define('output'(_L_), ?output(_L_, [])).
+-define('output'(_L_), io:put_chars(_L_)).
 
 -define(DEFAULT_FORMATTER, #{application => observer_cli, mod => observer_cli_formatter_default}).

--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -715,7 +715,7 @@ top_n_rows(FormatFunc, Start, List) ->
     {Row, PidList}.
 
 notify_pause_status() ->
-    ?output("\e[31;1m PAUSE  INPUT (p, r/rr, b/bb, h/hh, m/mm) to resume or q to quit \e[0m~n").
+    ?output("\e[31;1m PAUSE  INPUT (p, r/rr, b/bb, h/hh, m/mm) to resume or q to quit \e[0m\n").
 
 get_rank_format(Type, Pos, RankPos) ->
     MemSelected = "|\e[42m~-3.3w|~-12.12s|~13.13s |~-45.45s|~14.14s| ~-9.9s|~-33.33s\e[49m|~n",


### PR DESCRIPTION
If a process has a `~` in the name, it breaks the user interface.