### PR TITLE
Add OTP 29 CI, pin plugins, and fix ETS error handling

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - otp: '29'
+            rebar3: '3.26'
           - otp: '28'
             rebar3: '3.24'
           - otp: '27'
@@ -31,7 +33,7 @@ jobs:
           epmd -daemon
           rebar3 as test do eunit, covertool generate
       - name: Upload coverage reports to Codecov
-        if: matrix.otp == '28'
+        if: matrix.otp == '29'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 50%
+        threshold: 0%

--- a/elvis.config
+++ b/elvis.config
@@ -1,32 +1,29 @@
-[{elvis, [
+[
     {config, [
-        #{ dirs    => ["src"]
-         , filter  => "*.erl"
+        #{ files   => ["src/*.erl"]
          , ruleset => erl_files
          , rules   => [
-             {elvis_text_style, line_length, #{limit => 140}},
+             {elvis_text_style, max_line_length, #{limit => 140}},
              {elvis_style, atom_naming_convention, #{ignore => [observer_cli_mnesia]}},
              {elvis_style, param_pattern_matching, disable},
              {elvis_style, no_receive_without_timeout, disable},
              {elvis_style, no_block_expressions, disable},
-             {elvis_style, dont_repeat_yourself, disable},             
+             {elvis_style, dont_repeat_yourself, disable},
              {elvis_style, no_debug_call, #{ignore => [observer_cli_escriptize]}},
              {elvis_style, no_if_expression, disable},
-             {elvis_style, no_catch_expressions, disable},             
-             {elvis_style, export_used_types, disable}             
+             {elvis_style, no_catch_expressions, disable},
+             {elvis_style, export_used_types, disable}
          ]
         }
-      , #{ dirs    => ["include"]
-         , filter  => "*.hrl"
+      , #{ files   => ["include/*.hrl"]
          , ruleset => hrl_files
          , rules   => [
-             {elvis_text_style, line_length, #{limit => 140}},
+             {elvis_text_style, max_line_length, #{limit => 140}},
              {elvis_style, no_types, disable},
              {elvis_style, macro_naming_convention, disable}
          ]
         }
-      , #{ dirs    => ["."]
-         , filter  => "rebar.config"
+      , #{ files   => ["rebar.config"]
          , ruleset => rebar_config
         }
     ]}
@@ -34,4 +31,4 @@
   , {verbose, true}
   , {no_output, false}
   , {parallel, 1}
-]}].
+].

--- a/rebar.config
+++ b/rebar.config
@@ -21,10 +21,10 @@
 ]}.
 
 {project_plugins, [
-    erlfmt,
-    covertool,
-    rebar3_lint,
-    rebar3_ex_doc
+    {erlfmt, "1.8.0"},
+    {covertool, "2.0.7"},
+    {rebar3_lint, "4.2.3"},
+    {rebar3_ex_doc, "0.2.31"}
 ]}.
 
 {shell, [

--- a/rebar.config
+++ b/rebar.config
@@ -20,10 +20,16 @@
     recon
 ]}.
 
+{overrides, [
+    {override, recon, [
+        {erl_opts, [debug_info, nowarn_missing_spec]}
+    ]}
+]}.
+
 {project_plugins, [
     {erlfmt, "1.8.0"},
     {covertool, "2.0.7"},
-    {rebar3_lint, "4.2.3"},
+    {rebar3_lint, "5.0.3"},
     {rebar3_ex_doc, "0.2.31"}
 ]}.
 

--- a/src/observer_cli_ets.erl
+++ b/src/observer_cli_ets.erl
@@ -132,9 +132,7 @@ render_ets_info(Rows, CurPage, Attr) ->
     [Title | RowView].
 
 get_ets_info(Tab, Attr) ->
-    case catch ets:info(Tab) of
-        {'EXIT', _} ->
-            unread();
+    try ets:info(Tab) of
         undefined ->
             unread();
         Info when is_list(Info) ->
@@ -149,6 +147,9 @@ get_ets_info(Tab, Attr) ->
                 proplists:get_value(Attr, NewInfo),
                 NewInfo
             }
+    catch
+        _:_ ->
+            unread()
     end.
 
 is_reg(Owner) ->


### PR DESCRIPTION
Add an OTP 29 matrix entry to CI (rebar3 3.26) and update the Codecov upload condition to run for OTP 29. Pin project plugins in rebar.config to explicit versions for reproducible builds. In src/observer_cli_ets.erl replace the old catch-based ets:info handling with a try/catch to more robustly handle errors when inspecting ETS tables and return unread() on failures.