### PR TITLE
Adapt terminal layout to current width

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Observer CLI is a library to be dropped into any BEAM nodes, to be used to help 
 %% rebar.config
 {deps, [observer_cli]}
 %% erlang.mk
-dep_observer_cli = hex 1.8.7
+dep_observer_cli = hex 1.8.8
 ```
 
 ### Elixir

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+- 1.8.8
+  - Automatically adapt terminal layout width across Home, Application, ETS, Mnesia, Network, Process, Port, System, and less footers.
+  - Reorganize Doc help shortcuts into clearer command groups.
+  - Relax the Elvis god-module rule for existing large renderer modules.
+
 - 1.8.7
   - Handle unchanged case in `net_kernel:set_net_ticktime`.
   - Fix `rebar3 check` by updating the Elvis macro rule name to `macro_naming_convention`.

--- a/elvis.config
+++ b/elvis.config
@@ -9,6 +9,7 @@
              {elvis_style, no_receive_without_timeout, disable},
              {elvis_style, no_block_expressions, disable},
              {elvis_style, dont_repeat_yourself, disable},
+             {elvis_style, no_god_modules, disable},
              {elvis_style, no_debug_call, #{ignore => [observer_cli_escriptize]}},
              {elvis_style, no_if_expression, disable},
              {elvis_style, no_catch_expressions, disable},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ObserverCli.MixProject do
   def project do
     [
       app: :observer_cli,
-      version: "1.8.7",
+      version: "1.8.8",
       language: :erlang,
       description: "observer in shell",
       deps: [

--- a/src/less_client.erl
+++ b/src/less_client.erl
@@ -114,17 +114,12 @@ handle_page({_LessServer, Header, Nav, Footer}, Page) ->
 render_last_line(Nav) ->
     PrevKey =
         case maps:is_key("B\n", Nav) of
-            true -> <<"k(previous page)">>;
-            false -> <<"B/k(previous page)">>
+            true -> "k(previous page)";
+            false -> "B/k(previous page)"
         end,
-    unicode:characters_to_binary([
-        <<"|">>,
-        ?GRAY_BG,
-        <<"q(quit) F/j(next page) ">>,
-        PrevKey,
-        ?RESET,
-        <<"\n">>
-    ]).
+    unicode:characters_to_binary(
+        observer_cli_lib:render_last_line(["q(quit) F/j(next page) ", PrevKey])
+    ).
 
 header_lines(undefined) -> 0;
 header_lines(_Header) -> 1.

--- a/src/observer_cli.app.src
+++ b/src/observer_cli.app.src
@@ -1,6 +1,6 @@
 {application, observer_cli, [
     {description, "Visualize Erlang Nodes On The Command Line"},
-    {vsn, "1.8.7"},
+    {vsn, "1.8.8"},
     {modules, [observer_cli]},
     {registered, []},
     {applications, [kernel, stdlib, recon]},

--- a/src/observer_cli.erl
+++ b/src/observer_cli.erl
@@ -6,6 +6,7 @@
 
 %% proc_lib:get_label/1 is not exported before OTP 27
 -dialyzer([{nowarn_function, [choose_label/1]}]).
+
 -ignore_xref({proc_lib, get_label, 1}).
 
 %% API
@@ -16,11 +17,12 @@
 -export([clean/1]).
 
 -ifdef(TEST).
+
 -export([
     render_system_line/2,
     render_memory_process_line/3,
     render_scheduler_usage/1,
-    render_top_n_view/5,
+    render_top_n_view/5, render_top_n_view/6,
     transform_seq/3,
     process_bar_format_style/2,
     warning_color/1,
@@ -37,6 +39,7 @@
     get_incremental_stats/1,
     check_auto_row/0
 ]).
+
 -endif.
 
 %% cpu >= this value will be highlight
@@ -44,12 +47,14 @@
 %% port or process reach max_limit * 0.85 will be highlight
 -define(COUNT_ALARM_THRESHOLD, 0.85).
 -define(LAST_LINE,
-    "q(quit) p(pause) r/rr(reduction) m/mm(mem)"
-    "b/bb(binary mem) t/tt(total heap size) mq/mmq(msg queue) 9(proc 9 info) F/B(page forward/back)"
+    "q(quit) p(pause) r/rr(reduction) m/mm(mem)b/bb(binary mem) "
+    "t/tt(total heap size) mq/mmq(msg queue) 9(proc 9 info) F/B(page "
+    "forward/back)"
 ).
 
 -spec start() -> no_return() | {badrpc, term()}.
-start() -> start(#view_opts{}).
+start() ->
+    start(#view_opts{}).
 
 -spec start(Node) -> no_return() | {badrpc, term()} when
     Node :: atom() | non_neg_integer() | view_opts().
@@ -88,8 +93,10 @@ start(Node, Cookie) when is_atom(Node) andalso is_atom(Cookie) ->
     start(Node, [{cookie, Cookie}]);
 start(Node, Options) when is_atom(Node) andalso is_list(Options) ->
     case proplists:get_value(cookie, Options) of
-        undefined -> ok;
-        Cookie -> erlang:set_cookie(Node, Cookie)
+        undefined ->
+            ok;
+        Cookie ->
+            erlang:set_cookie(Node, Cookie)
     end,
     Interval = proplists:get_value(interval, Options, ?DEFAULT_INTERVAL),
     rpc_start(Node, Interval).
@@ -125,7 +132,15 @@ rpc_start(Node, Interval) ->
     end.
 
 manager(StorePid, RenderPid, Opts, LastSchWallFlag) ->
-    #view_opts{home = Home = #home{cur_page = CurPage, pages = Pages, scheduler_usage = SchUsage}} =
+    #view_opts{
+        home =
+            Home =
+                #home{
+                    cur_page = CurPage,
+                    pages = Pages,
+                    scheduler_usage = SchUsage
+                }
+    } =
         Opts,
     Resource = [RenderPid, StorePid, LastSchWallFlag, SchUsage],
     case observer_cli_lib:parse_cmd(Opts, ?MODULE, Resource) of
@@ -144,8 +159,10 @@ manager(StorePid, RenderPid, Opts, LastSchWallFlag) ->
         scheduler_usage ->
             NewSchUsage =
                 case SchUsage of
-                    ?DISABLE -> ?ENABLE;
-                    ?ENABLE -> ?DISABLE
+                    ?DISABLE ->
+                        ?ENABLE;
+                    ?ENABLE ->
+                        ?DISABLE
                 end,
             clean(Resource),
             start(Opts#view_opts{home = Home#home{scheduler_usage = NewSchUsage}});
@@ -179,7 +196,16 @@ render_worker(PsCmd, Manager, Home = #home{scheduler_usage = SchUsage}, AutoRow)
     ?output(?CLEAR),
     StableInfo = get_stable_system_info(),
     LastStats = get_incremental_stats(SchUsage),
-    redraw_running(PsCmd, Manager, Home, StableInfo, LastStats, erlang:make_ref(), AutoRow, true).
+    redraw_running(
+        PsCmd,
+        Manager,
+        Home,
+        StableInfo,
+        LastStats,
+        erlang:make_ref(),
+        AutoRow,
+        true
+    ).
 
 %% pause status waiting to be resume
 redraw_pause(PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRow) ->
@@ -191,14 +217,7 @@ redraw_pause(PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRow)
             quit;
         {Func, Type} ->
             redraw_running(
-                PsCmd,
-                StorePid,
-                Home,
-                StableInfo,
-                LastStats,
-                LastTimeRef,
-                AutoRow,
-                false
+                PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRow, false
             );
         pause_or_resume ->
             ?output(?CLEAR),
@@ -206,7 +225,16 @@ redraw_pause(PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRow)
     end.
 
 %% running status
-redraw_running(PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRow, IsFirstTime) ->
+redraw_running(
+    PsCmd,
+    StorePid,
+    Home,
+    StableInfo,
+    LastStats,
+    LastTimeRef,
+    AutoRow,
+    IsFirstTime
+) ->
     #home{
         interval = Interval,
         func = Func,
@@ -214,7 +242,8 @@ redraw_running(PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRo
         pages = RankPos,
         cur_page = CurPage,
         scheduler_usage = SchUsage
-    } = Home,
+    } =
+        Home,
     erlang:cancel_timer(LastTimeRef),
     TerminalRow = observer_cli_lib:get_terminal_rows(AutoRow),
     {Diffs, Schedulers, NewStats} = node_stats(LastStats, SchUsage),
@@ -242,6 +271,8 @@ redraw_running(PsCmd, StorePid, Home, StableInfo, LastStats, LastTimeRef, AutoRo
     end.
 
 render_system_line(PsCmd, StableInfo) ->
+    {LeftLabelExtra, LeftValueExtra, MiddleLabelExtra, MiddleValueExtra, RightLabelExtra,
+        RightValueExtra} = home_summary_extras(),
     [Version, SysVersion, ProcLimit, PortLimit, EtsLimit] = StableInfo,
     ActiveTask = erlang:statistics(total_active_tasks),
     {ContextSwitch, _} = erlang:statistics(context_switches),
@@ -250,42 +281,52 @@ render_system_line(PsCmd, StableInfo) ->
     {PortWarning, ProcWarning, PortCount, ProcCount} =
         get_port_proc_info(PortLimit, ProcLimit),
     CmdValue =
-        case string:split(os:cmd(PsCmd), "\n", all) of
-            [_, CmdValueTmp | _] -> CmdValueTmp;
-            _ -> ""
+        case
+            string:split(
+                os:cmd(PsCmd), "\n", all
+            )
+        of
+            [_, CmdValueTmp | _] ->
+                CmdValueTmp;
+            _ ->
+                ""
         end,
 
     [CpuPsV, MemPsV] =
         case lists:filter(fun(Y) -> Y =/= [] end, string:split(CmdValue, " ", all)) of
-            [V1, V2] -> [V1, V2];
-            _ -> ["--", "--"]
+            [V1, V2] ->
+                [V1, V2];
+            _ ->
+                ["--", "--"]
         end,
-    Title = ?render([
-        ?W(SysVersion, 136),
-        ?NEW_LINE,
-        ?GRAY_BG,
-        ?W("System", 10),
-        ?W("Count/Limit", 21),
-        ?W("System", 25),
-        ?W("Status", 21),
-        ?W("Stat Info", 20),
-        ?W("Size", 24)
-    ]),
-    Row1 = ?render([
-        ?W("Proc Count", 10),
-        ?W2(ProcWarning, ProcCount, 22),
-        ?W(" Version", 26),
-        ?W(Version, 21),
-        ?W("Active Task", 20),
-        ?W(ActiveTask, 24),
-        ?NEW_LINE,
-        ?W("Port Count", 10),
-        ?W2(PortWarning, PortCount, 22),
-        ?W(" ps -o pcpu", 26),
-        ?W([CpuPsV, "%"], 21),
-        ?W("Context Switch", 20),
-        ?W(ContextSwitch, 24)
-    ]),
+    Title =
+        ?render([
+            ?W(SysVersion, observer_cli_lib:layout_width() - 3),
+            ?NEW_LINE,
+            ?GRAY_BG,
+            ?W("System", 10 + LeftLabelExtra),
+            ?W("Count/Limit", 21 + LeftValueExtra),
+            ?W("System", 25 + MiddleLabelExtra),
+            ?W("Status", 21 + MiddleValueExtra),
+            ?W("Stat Info", 20 + RightLabelExtra),
+            ?W("Size", 25 + RightValueExtra)
+        ]),
+    Row1 =
+        ?render([
+            ?W("Proc Count", 10 + LeftLabelExtra),
+            ?W2(ProcWarning, ProcCount, 22 + LeftValueExtra),
+            ?W(" Version", 26 + MiddleLabelExtra),
+            ?W(Version, 21 + MiddleValueExtra),
+            ?W("Active Task", 20 + RightLabelExtra),
+            ?W(ActiveTask, 25 + RightValueExtra),
+            ?NEW_LINE,
+            ?W("Port Count", 10 + LeftLabelExtra),
+            ?W2(PortWarning, PortCount, 22 + LeftValueExtra),
+            ?W(" ps -o pcpu", 26 + MiddleLabelExtra),
+            ?W([CpuPsV, "%"], 21 + MiddleValueExtra),
+            ?W("Context Switch", 20 + RightLabelExtra),
+            ?W(ContextSwitch, 24 + RightValueExtra)
+        ]),
     {Reds, AddReds} = Reductions,
     Row2 =
         case AtomStatus of
@@ -293,27 +334,29 @@ render_system_line(PsCmd, StableInfo) ->
                 {AtomWarning, Atom} = format_atom_info(AtomLimit, AtomCount),
                 ?render([
                     ?UNDERLINE,
-                    ?W("Atom Count", 10),
-                    ?W2(AtomWarning, Atom, 22),
-                    ?W(" ps -o pmem", 26),
-                    ?W([MemPsV, "%"], 21),
-                    ?W("Reds(Total/SinceLastCall)", 20),
-                    ?W([integer_to_list(Reds), "/", integer_to_list(AddReds)], 24)
+                    ?W("Atom Count", 10 + LeftLabelExtra),
+                    ?W2(AtomWarning, Atom, 22 + LeftValueExtra),
+                    ?W(" ps -o pmem", 26 + MiddleLabelExtra),
+                    ?W([MemPsV, "%"], 21 + MiddleValueExtra),
+                    ?W("Reds(Total/SinceLastCall)", 20 + RightLabelExtra),
+                    ?W([integer_to_list(Reds), "/", integer_to_list(AddReds)], 24 + RightValueExtra)
                 ]);
             {error, unsupported} ->
                 ?render([
                     ?UNDERLINE,
-                    ?W("Ets Limit", 10),
-                    ?W(EtsLimit, 21),
-                    ?W(" ps -o pmem", 25),
-                    ?W([MemPsV, "%"], 21),
-                    ?W("Reductions", 20),
-                    ?W(Reductions, 24)
+                    ?W("Ets Limit", 10 + LeftLabelExtra),
+                    ?W(EtsLimit, 21 + LeftValueExtra),
+                    ?W(" ps -o pmem", 25 + MiddleLabelExtra),
+                    ?W([MemPsV, "%"], 21 + MiddleValueExtra),
+                    ?W("Reductions", 20 + RightLabelExtra),
+                    ?W(Reductions, 24 + RightValueExtra)
                 ])
         end,
     [Title, Row1, Row2].
 
 render_memory_process_line(MemSum, PortParallelism, Interval) ->
+    {LeftLabelExtra, LeftValueExtra, MiddleLabelExtra, MiddleValueExtra, RightLabelExtra,
+        RightValueExtra} = home_summary_extras(),
     RunQ = erlang:statistics(run_queue),
     Mem = erlang:memory(),
     TotalMem = proplists:get_value(total, Mem),
@@ -322,13 +365,11 @@ render_memory_process_line(MemSum, PortParallelism, Interval) ->
     AtomMem = proplists:get_value(atom_used, Mem),
     BinMem = proplists:get_value(binary, Mem),
     EtsMem = proplists:get_value(ets, Mem),
-    EtsLen = erlang:length(ets:all()),
-    {
-        BytesIn,
-        BytesOut,
-        GcCount,
-        GcWordsReclaimed
-    } = MemSum,
+    EtsLen =
+        erlang:length(
+            ets:all()
+        ),
+    {BytesIn, BytesOut, GcCount, GcWordsReclaimed} = MemSum,
 
     {Queue, LogKey} =
         case whereis(error_logger) of
@@ -347,51 +388,73 @@ render_memory_process_line(MemSum, PortParallelism, Interval) ->
     CodeMemPercent = observer_cli_lib:to_percent(CodeMem / TotalMem),
     EtsMemPercent = observer_cli_lib:to_percent(EtsMem / TotalMem),
 
-    Title = ?render([
-        ?GRAY_BG,
-        ?W("Mem Type", 10),
-        ?W("Size", 21),
-        ?W("Mem Type", 25),
-        ?W("Size", 21),
-        ?W(["IO/GC:(", integer_to_binary(Interval), "ms)"], 20),
-        ?W("Total/Increments", 24)
-    ]),
-    Row = ?render([
-        ?W("Total", 10),
-        ?W({byte, TotalMem}, 12),
-        ?W("100.0%", 6),
-        ?W("Binary", 25),
-        ?W({byte, BinMem}, 12),
-        ?W(BinMemPercent, 6),
-        ?W("IO Output", 20),
-        ?W(BytesOut, 24),
-        ?NEW_LINE,
-        ?W("Process", 10),
-        ?W({byte, ProcMem}, 12),
-        ?W(ProcMemPercent, 6),
-        ?W("Code", 25),
-        ?W({byte, CodeMem}, 12),
-        ?W(CodeMemPercent, 6),
-        ?W("IO Input", 20),
-        ?W(BytesIn, 24),
-        ?NEW_LINE,
-        ?W("Atom", 10),
-        ?W({byte, AtomMem}, 12),
-        ?W(AtomMemPercent, 6),
-        ?W("Port Parallelism (+spp)", 25),
-        ?W(PortParallelism, 21),
-        ?W("Gc Count", 20),
-        ?W(GcCount, 24),
-        ?NEW_LINE,
-        ?W("Ets/" ++ erlang:integer_to_list(EtsLen), 10),
-        ?W({byte, EtsMem}, 12),
-        ?W(EtsMemPercent, 6),
-        ?W(LogKey, 25),
-        ?W(Queue, 21),
-        ?W("Gc Words Reclaimed", 20),
-        ?W(GcWordsReclaimed, 24)
-    ]),
+    Title =
+        ?render([
+            ?GRAY_BG,
+            ?W("Mem Type", 10 + LeftLabelExtra),
+            ?W("Size", 21 + LeftValueExtra),
+            ?W("Mem Type", 25 + MiddleLabelExtra),
+            ?W("Size", 21 + MiddleValueExtra),
+            ?W(["IO/GC:(", integer_to_binary(Interval), "ms)"], 20 + RightLabelExtra),
+            ?W("Total/Increments", 24 + RightValueExtra)
+        ]),
+    Row =
+        ?render([
+            ?W("Total", 10 + LeftLabelExtra),
+            ?W({byte, TotalMem}, 12),
+            ?W("100.0%", 6 + LeftValueExtra),
+            ?W("Binary", 25 + MiddleLabelExtra),
+            ?W({byte, BinMem}, 12),
+            ?W(BinMemPercent, 6 + MiddleValueExtra),
+            ?W("IO Output", 20 + RightLabelExtra),
+            ?W(BytesOut, 25 + RightValueExtra),
+            ?NEW_LINE,
+            ?W("Process", 10 + LeftLabelExtra),
+            ?W({byte, ProcMem}, 12),
+            ?W(ProcMemPercent, 6 + LeftValueExtra),
+            ?W("Code", 25 + MiddleLabelExtra),
+            ?W({byte, CodeMem}, 12),
+            ?W(CodeMemPercent, 6 + MiddleValueExtra),
+            ?W("IO Input", 20 + RightLabelExtra),
+            ?W(BytesIn, 25 + RightValueExtra),
+            ?NEW_LINE,
+            ?W("Atom", 10 + LeftLabelExtra),
+            ?W({byte, AtomMem}, 12),
+            ?W(AtomMemPercent, 6 + LeftValueExtra),
+            ?W("Port Parallelism (+spp)", 25 + MiddleLabelExtra),
+            ?W(PortParallelism, 21 + MiddleValueExtra),
+            ?W("Gc Count", 20 + RightLabelExtra),
+            ?W(GcCount, 25 + RightValueExtra),
+            ?NEW_LINE,
+            ?W("Ets/" ++ erlang:integer_to_list(EtsLen), 10 + LeftLabelExtra),
+            ?W({byte, EtsMem}, 12),
+            ?W(EtsMemPercent, 6 + LeftValueExtra),
+            ?W(LogKey, 25 + MiddleLabelExtra),
+            ?W(Queue, 21 + MiddleValueExtra),
+            ?W("Gc Words Reclaimed", 20 + RightLabelExtra),
+            ?W(GcWordsReclaimed, 24 + RightValueExtra)
+        ]),
     [Title, Row].
+
+home_summary_extras() ->
+    Extra = erlang:max(observer_cli_lib:layout_width() - (?COLUMN + 6), 0),
+    PerColumn = Extra div 6,
+    Remainder = Extra rem 6,
+    RawMiddleValueExtra = PerColumn + extra_bit(Remainder, 4),
+    RightValueShift = erlang:min(RawMiddleValueExtra, 1),
+    {
+        PerColumn + extra_bit(Remainder, 1),
+        PerColumn + extra_bit(Remainder, 2),
+        PerColumn + extra_bit(Remainder, 3),
+        RawMiddleValueExtra - RightValueShift,
+        PerColumn + extra_bit(Remainder, 5),
+        PerColumn + RightValueShift
+    }.
+
+extra_bit(Rem, Pos) when Rem >= Pos ->
+    1;
+extra_bit(_Rem, _Pos) ->
+    0.
 
 render_scheduler_usage(undefined) ->
     {0, []};
@@ -403,310 +466,347 @@ render_scheduler_usage(SchedulerUsage) ->
 render_scheduler_usage(SchedulerUsage, SchedulerNum) when SchedulerNum < 8 ->
     Column =
         case SchedulerNum rem 2 =:= 0 of
-            true -> SchedulerNum div 2;
-            false -> (SchedulerNum div 2) + 1
+            true ->
+                SchedulerNum div 2;
+            false ->
+                SchedulerNum div 2 + 1
         end,
-    CPU = [
-        begin
-            Seq2 = transform_seq(Seq1, Column, SchedulerNum),
-            Percent1 = proplists:get_value(Seq1, SchedulerUsage, 0.0),
-            Percent2 = proplists:get_value(Seq2, SchedulerUsage, 0.0),
-            CPU1 = observer_cli_lib:to_percent(Percent1),
-            CPU2 = observer_cli_lib:to_percent(Percent2),
-            Process1 = lists:duplicate(trunc(Percent1 * 57), "|"),
-            Process2 = lists:duplicate(trunc(Percent2 * 57), "|"),
-            IsLastLine = Seq1 =:= Column,
-            Format = process_bar_format_style([Percent1, Percent2], IsLastLine),
-            io_lib:format(Format, [
-                Seq1,
-                Process1,
-                CPU1,
-                Seq2,
-                Process2,
-                CPU2
-            ])
-        end
-     || Seq1 <- lists:seq(1, Column)
-    ],
-    {Column, CPU};
+    CPU =
+        [
+            begin
+                Seq2 = transform_seq(Seq1, Column, SchedulerNum),
+                Percent1 = proplists:get_value(Seq1, SchedulerUsage, 0.0),
+                Percent2 = proplists:get_value(Seq2, SchedulerUsage, 0.0),
+                CPU1 = observer_cli_lib:to_percent(Percent1),
+                CPU2 = observer_cli_lib:to_percent(Percent2),
+                Process1 = lists:duplicate(trunc(Percent1 * 57), "|"),
+                Process2 = lists:duplicate(trunc(Percent2 * 57), "|"),
+                IsLastLine = Seq1 =:= Column,
+                Format = process_bar_format_style([Percent1, Percent2], IsLastLine),
+                io_lib:format(Format, [Seq1, Process1, CPU1, Seq2, Process2, CPU2])
+            end
+         || Seq1 <- lists:seq(1, Column)
+        ],
+    {Column, pad_scheduler_lines(CPU)};
 %% 100 >= scheduler >= 8 split 4 part
 render_scheduler_usage(SchedulerUsage, SchedulerNum) when SchedulerNum =< 100 ->
     Column =
         case SchedulerNum rem 4 =:= 0 of
-            true -> SchedulerNum div 4;
-            false -> (SchedulerNum div 4) + 1
+            true ->
+                SchedulerNum div 4;
+            false ->
+                SchedulerNum div 4 + 1
         end,
-    CPU = [
-        begin
-            Seq2 = transform_seq(Seq1, Column, SchedulerNum),
-            Seq3 = transform_seq(Seq2, Column, SchedulerNum),
-            Seq4 = transform_seq(Seq3, Column, SchedulerNum),
-            Percent1 = proplists:get_value(Seq1, SchedulerUsage, 0.0),
-            Percent2 = proplists:get_value(Seq2, SchedulerUsage, 0.0),
-            Percent3 = proplists:get_value(Seq3, SchedulerUsage, 0.0),
-            Percent4 = proplists:get_value(Seq4, SchedulerUsage, 0.0),
-            CPU1 = observer_cli_lib:to_percent(Percent1),
-            CPU2 = observer_cli_lib:to_percent(Percent2),
-            CPU3 = observer_cli_lib:to_percent(Percent3),
-            CPU4 = observer_cli_lib:to_percent(Percent4),
-            Process1 = lists:duplicate(trunc(Percent1 * 22), "|"),
-            Process2 = lists:duplicate(trunc(Percent2 * 22), "|"),
-            Process3 = lists:duplicate(trunc(Percent3 * 22), "|"),
-            Process4 = lists:duplicate(trunc(Percent4 * 23), "|"),
-            IsLastLine = Seq1 =:= Column,
-            Format = process_bar_format_style([Percent1, Percent2, Percent3, Percent4], IsLastLine),
-            io_lib:format(Format, [
-                Seq1,
-                Process1,
-                CPU1,
-                Seq2,
-                Process2,
-                CPU2,
-                Seq3,
-                Process3,
-                CPU3,
-                Seq4,
-                Process4,
-                CPU4
-            ])
-        end
-     || Seq1 <- lists:seq(1, Column)
-    ],
-    {Column, CPU};
+    CPU =
+        [
+            begin
+                Seq2 = transform_seq(Seq1, Column, SchedulerNum),
+                Seq3 = transform_seq(Seq2, Column, SchedulerNum),
+                Seq4 = transform_seq(Seq3, Column, SchedulerNum),
+                Percent1 = proplists:get_value(Seq1, SchedulerUsage, 0.0),
+                Percent2 = proplists:get_value(Seq2, SchedulerUsage, 0.0),
+                Percent3 = proplists:get_value(Seq3, SchedulerUsage, 0.0),
+                Percent4 = proplists:get_value(Seq4, SchedulerUsage, 0.0),
+                CPU1 = observer_cli_lib:to_percent(Percent1),
+                CPU2 = observer_cli_lib:to_percent(Percent2),
+                CPU3 = observer_cli_lib:to_percent(Percent3),
+                CPU4 = observer_cli_lib:to_percent(Percent4),
+                Process1 = lists:duplicate(trunc(Percent1 * 22), "|"),
+                Process2 = lists:duplicate(trunc(Percent2 * 22), "|"),
+                Process3 = lists:duplicate(trunc(Percent3 * 22), "|"),
+                Process4 = lists:duplicate(trunc(Percent4 * 23), "|"),
+                IsLastLine = Seq1 =:= Column,
+                Format = process_bar_format_style(
+                    [Percent1, Percent2, Percent3, Percent4], IsLastLine
+                ),
+                io_lib:format(
+                    Format,
+                    [
+                        Seq1,
+                        Process1,
+                        CPU1,
+                        Seq2,
+                        Process2,
+                        CPU2,
+                        Seq3,
+                        Process3,
+                        CPU3,
+                        Seq4,
+                        Process4,
+                        CPU4
+                    ]
+                )
+            end
+         || Seq1 <- lists:seq(1, Column)
+        ],
+    {Column, pad_scheduler_lines(CPU)};
 %% scheduler > 100 don't show process bar.
 render_scheduler_usage(SchedulerUsage, SchedulerNum) ->
     Column =
         case SchedulerNum rem 10 =:= 0 of
-            true -> SchedulerNum div 10;
-            false -> (SchedulerNum div 10) + 1
+            true ->
+                SchedulerNum div 10;
+            false ->
+                SchedulerNum div 10 + 1
         end,
-    CPU = [
-        begin
-            Seq2 = transform_seq(Seq1, Column, SchedulerNum),
-            Seq3 = transform_seq(Seq2, Column, SchedulerNum),
-            Seq4 = transform_seq(Seq3, Column, SchedulerNum),
-            Seq5 = transform_seq(Seq4, Column, SchedulerNum),
-            Seq6 = transform_seq(Seq5, Column, SchedulerNum),
-            Seq7 = transform_seq(Seq6, Column, SchedulerNum),
-            Seq8 = transform_seq(Seq7, Column, SchedulerNum),
-            Seq9 = transform_seq(Seq8, Column, SchedulerNum),
-            Seq10 = transform_seq(Seq9, Column, SchedulerNum),
-            Percent1 = proplists:get_value(Seq1, SchedulerUsage),
-            Percent2 = proplists:get_value(Seq2, SchedulerUsage),
-            Percent3 = proplists:get_value(Seq3, SchedulerUsage),
-            Percent4 = proplists:get_value(Seq4, SchedulerUsage),
-            Percent5 = proplists:get_value(Seq5, SchedulerUsage),
-            Percent6 = proplists:get_value(Seq6, SchedulerUsage),
-            Percent7 = proplists:get_value(Seq7, SchedulerUsage),
-            Percent8 = proplists:get_value(Seq8, SchedulerUsage),
-            Percent9 = proplists:get_value(Seq9, SchedulerUsage),
-            Percent10 = proplists:get_value(Seq10, SchedulerUsage),
-            CPU1 = observer_cli_lib:to_percent(Percent1),
-            CPU2 = observer_cli_lib:to_percent(Percent2),
-            CPU3 = observer_cli_lib:to_percent(Percent3),
-            CPU4 = observer_cli_lib:to_percent(Percent4),
-            CPU5 = observer_cli_lib:to_percent(Percent5),
-            CPU6 = observer_cli_lib:to_percent(Percent6),
-            CPU7 = observer_cli_lib:to_percent(Percent7),
-            CPU8 = observer_cli_lib:to_percent(Percent8),
-            CPU9 = observer_cli_lib:to_percent(Percent9),
-            CPU10 = observer_cli_lib:to_percent(Percent10),
-            IsLastLine = Seq1 =:= Column,
-            Percents = [
-                Percent1,
-                Percent2,
-                Percent3,
-                Percent4,
-                Percent5,
-                Percent6,
-                Percent7,
-                Percent8,
-                Percent9,
-                Percent10
-            ],
-            Format = process_bar_format_style(Percents, IsLastLine),
-            io_lib:format(Format, [
-                Seq1,
-                CPU1,
-                Seq2,
-                CPU2,
-                Seq3,
-                CPU3,
-                Seq4,
-                CPU4,
-                Seq5,
-                CPU5,
-                Seq6,
-                CPU6,
-                Seq7,
-                CPU7,
-                Seq8,
-                CPU8,
-                Seq9,
-                CPU9,
-                Seq10,
-                CPU10
-            ])
-        end
-     || Seq1 <- lists:seq(1, Column)
-    ],
-    {Column, CPU}.
+    CPU =
+        [
+            begin
+                Seq2 = transform_seq(Seq1, Column, SchedulerNum),
+                Seq3 = transform_seq(Seq2, Column, SchedulerNum),
+                Seq4 = transform_seq(Seq3, Column, SchedulerNum),
+                Seq5 = transform_seq(Seq4, Column, SchedulerNum),
+                Seq6 = transform_seq(Seq5, Column, SchedulerNum),
+                Seq7 = transform_seq(Seq6, Column, SchedulerNum),
+                Seq8 = transform_seq(Seq7, Column, SchedulerNum),
+                Seq9 = transform_seq(Seq8, Column, SchedulerNum),
+                Seq10 = transform_seq(Seq9, Column, SchedulerNum),
+                Percent1 = proplists:get_value(Seq1, SchedulerUsage),
+                Percent2 = proplists:get_value(Seq2, SchedulerUsage),
+                Percent3 = proplists:get_value(Seq3, SchedulerUsage),
+                Percent4 = proplists:get_value(Seq4, SchedulerUsage),
+                Percent5 = proplists:get_value(Seq5, SchedulerUsage),
+                Percent6 = proplists:get_value(Seq6, SchedulerUsage),
+                Percent7 = proplists:get_value(Seq7, SchedulerUsage),
+                Percent8 = proplists:get_value(Seq8, SchedulerUsage),
+                Percent9 = proplists:get_value(Seq9, SchedulerUsage),
+                Percent10 = proplists:get_value(Seq10, SchedulerUsage),
+                CPU1 = observer_cli_lib:to_percent(Percent1),
+                CPU2 = observer_cli_lib:to_percent(Percent2),
+                CPU3 = observer_cli_lib:to_percent(Percent3),
+                CPU4 = observer_cli_lib:to_percent(Percent4),
+                CPU5 = observer_cli_lib:to_percent(Percent5),
+                CPU6 = observer_cli_lib:to_percent(Percent6),
+                CPU7 = observer_cli_lib:to_percent(Percent7),
+                CPU8 = observer_cli_lib:to_percent(Percent8),
+                CPU9 = observer_cli_lib:to_percent(Percent9),
+                CPU10 = observer_cli_lib:to_percent(Percent10),
+                IsLastLine = Seq1 =:= Column,
+                Percents =
+                    [
+                        Percent1,
+                        Percent2,
+                        Percent3,
+                        Percent4,
+                        Percent5,
+                        Percent6,
+                        Percent7,
+                        Percent8,
+                        Percent9,
+                        Percent10
+                    ],
+                Format = process_bar_format_style(Percents, IsLastLine),
+                io_lib:format(
+                    Format,
+                    [
+                        Seq1,
+                        CPU1,
+                        Seq2,
+                        CPU2,
+                        Seq3,
+                        CPU3,
+                        Seq4,
+                        CPU4,
+                        Seq5,
+                        CPU5,
+                        Seq6,
+                        CPU6,
+                        Seq7,
+                        CPU7,
+                        Seq8,
+                        CPU8,
+                        Seq9,
+                        CPU9,
+                        Seq10,
+                        CPU10
+                    ]
+                )
+            end
+         || Seq1 <- lists:seq(1, Column)
+        ],
+    {Column, pad_scheduler_lines(CPU)}.
+
+pad_scheduler_lines(Lines) ->
+    [observer_cli_lib:pad_rendered(Line) || Line <- Lines].
 
 transform_seq(Seq, Column, Total) ->
     Num = Seq + Column,
     case Num > Total of
-        true -> 1000;
-        false -> Num
+        true ->
+            1000;
+        false ->
+            Num
     end.
 
-render_top_n_view(memory, MemoryList, Num, Pages, Page) ->
-    Title = ?render([
-        ?W2(?GRAY_BG, "No | Pid", 16),
-        ?W2(?RED_BG, "     Memory", 14),
-        ?W(?GRAY_BG, "Name|>Label|>Initial Call", 45),
-        ?W(?GRAY_BG, "    Reductions", 14),
-        ?W(?GRAY_BG, " MsgQueue", 10),
-        ?W(?GRAY_BG, "Current Function", 32)
-    ]),
-    {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(MemoryList)),
-    FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
-        {Pid, MemVal, CurFun, NameOrCall} = get_top_n_info(Item),
-        {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
-        Format = get_rank_format(memory, ChoosePos, Pos),
-        R = io_lib:format(
-            Format,
-            [
-                Pos,
-                erlang:pid_to_list(Pid),
-                observer_cli_lib:to_byte(MemVal),
-                NameOrCall,
-                observer_cli_lib:to_list(Reductions),
-                observer_cli_lib:to_list(MsgQueueLen),
-                CurFun
-            ]
-        ),
-        {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
-    end,
+render_top_n_view(Type, List, Num, Pages, Page) ->
+    render_top_n_view(Type, List, Num, Pages, Page, observer_cli_lib:layout_width()).
+
+render_top_n_view(memory, MemoryList, Num, Pages, Page, LayoutWidth) ->
+    {NameWidth, CurrentTitleWidth, CurrentWidth} = top_n_text_widths(45, 32, 33, LayoutWidth),
+    Title =
+        ?render([
+            ?W2(?GRAY_BG, "No | Pid", 16),
+            ?W2(?RED_BG, "     Memory", 14),
+            ?W(?GRAY_BG, "Name|>Label|>Initial Call", NameWidth),
+            ?W(?GRAY_BG, "    Reductions", 14),
+            ?W(?GRAY_BG, " MsgQueue", 10),
+            ?W(?GRAY_BG, "Current Function", CurrentTitleWidth)
+        ]),
+    {Start, ChoosePos} =
+        observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(MemoryList)),
+    FormatFunc =
+        fun(Item, {Acc, Acc1, Pos}) ->
+            {Pid, MemVal, CurFun, NameOrCall} = get_top_n_info(Item),
+            {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
+            Format = get_rank_format(memory, ChoosePos, Pos, NameWidth, CurrentWidth),
+            R = io_lib:format(
+                Format,
+                [
+                    Pos,
+                    erlang:pid_to_list(Pid),
+                    observer_cli_lib:to_byte(MemVal),
+                    NameOrCall,
+                    observer_cli_lib:to_list(Reductions),
+                    observer_cli_lib:to_list(MsgQueueLen),
+                    CurFun
+                ]
+            ),
+            {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
+        end,
     {Rows, PidList} = top_n_rows(FormatFunc, Start, lists:sublist(MemoryList, Start, Num)),
     {PidList, [Title | lists:reverse(Rows)]};
-render_top_n_view(binary_memory, MemoryList, Num, Pages, Page) ->
-    Title = ?render([
-        ?W2(?GRAY_BG, "No | Pid", 16),
-        ?W2(?RED_BG, "  BinMemory", 14),
-        ?W(?GRAY_BG, "Name|>Label|>Initial Call", 45),
-        ?W(?GRAY_BG, "    Reductions", 14),
-        ?W(?GRAY_BG, " MsgQueue", 10),
-        ?W(?GRAY_BG, "Current Function", 32)
-    ]),
-    {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(MemoryList)),
-    FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
-        {Pid, MemVal, CurFun, NameOrCall} = get_top_n_info(Item),
-        {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
-        Format = get_rank_format(binary_memory, ChoosePos, Pos),
-        R = io_lib:format(
-            Format,
-            [
-                Pos,
-                pid_to_list(Pid),
-                observer_cli_lib:to_byte(MemVal),
-                NameOrCall,
-                observer_cli_lib:to_list(Reductions),
-                observer_cli_lib:to_list(MsgQueueLen),
-                CurFun
-            ]
-        ),
-        {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
-    end,
+render_top_n_view(binary_memory, MemoryList, Num, Pages, Page, LayoutWidth) ->
+    {NameWidth, CurrentTitleWidth, CurrentWidth} = top_n_text_widths(45, 32, 33, LayoutWidth),
+    Title =
+        ?render([
+            ?W2(?GRAY_BG, "No | Pid", 16),
+            ?W2(?RED_BG, "  BinMemory", 14),
+            ?W(?GRAY_BG, "Name|>Label|>Initial Call", NameWidth),
+            ?W(?GRAY_BG, "    Reductions", 14),
+            ?W(?GRAY_BG, " MsgQueue", 10),
+            ?W(?GRAY_BG, "Current Function", CurrentTitleWidth)
+        ]),
+    {Start, ChoosePos} =
+        observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(MemoryList)),
+    FormatFunc =
+        fun(Item, {Acc, Acc1, Pos}) ->
+            {Pid, MemVal, CurFun, NameOrCall} = get_top_n_info(Item),
+            {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
+            Format = get_rank_format(binary_memory, ChoosePos, Pos, NameWidth, CurrentWidth),
+            R = io_lib:format(
+                Format,
+                [
+                    Pos,
+                    pid_to_list(Pid),
+                    observer_cli_lib:to_byte(MemVal),
+                    NameOrCall,
+                    observer_cli_lib:to_list(Reductions),
+                    observer_cli_lib:to_list(MsgQueueLen),
+                    CurFun
+                ]
+            ),
+            {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
+        end,
     {Rows, PidList} = top_n_rows(FormatFunc, Start, lists:sublist(MemoryList, Start, Num)),
     {PidList, [Title | lists:reverse(Rows)]};
-render_top_n_view(reductions, ReductionList, Num, Pages, Page) ->
-    Title = ?render([
-        ?W2(?GRAY_BG, "No | Pid", 16),
-        ?W2(?RED_BG, "   Reductions", 15),
-        ?W(?GRAY_BG, "Name|>Label|>Initial Call", 45),
-        ?W(?GRAY_BG, "      Memory", 13),
-        ?W(?GRAY_BG, " MsgQueue", 10),
-        ?W(?GRAY_BG, "Current Function", 33)
-    ]),
-    {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(ReductionList)),
-    FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
-        {Pid, Reductions, CurFun, NameOrCall} = get_top_n_info(Item),
-        {Memory, MsgQueueLen} = get_pid_info(Pid, [memory, message_queue_len]),
-        Format = get_rank_format(reductions, ChoosePos, Pos),
-        R = io_lib:format(
-            Format,
-            [
-                Pos,
-                pid_to_list(Pid),
-                observer_cli_lib:to_list(Reductions),
-                NameOrCall,
-                observer_cli_lib:to_byte(Memory),
-                observer_cli_lib:to_list(MsgQueueLen),
-                CurFun
-            ]
-        ),
-        {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
-    end,
+render_top_n_view(reductions, ReductionList, Num, Pages, Page, LayoutWidth) ->
+    {NameWidth, CurrentTitleWidth, CurrentWidth} = top_n_text_widths(45, 33, 34, LayoutWidth),
+    Title =
+        ?render([
+            ?W2(?GRAY_BG, "No | Pid", 16),
+            ?W2(?RED_BG, "   Reductions", 15),
+            ?W(?GRAY_BG, "Name|>Label|>Initial Call", NameWidth),
+            ?W(?GRAY_BG, "      Memory", 13),
+            ?W(?GRAY_BG, " MsgQueue", 10),
+            ?W(?GRAY_BG, "Current Function", CurrentTitleWidth)
+        ]),
+    {Start, ChoosePos} =
+        observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(ReductionList)),
+    FormatFunc =
+        fun(Item, {Acc, Acc1, Pos}) ->
+            {Pid, Reductions, CurFun, NameOrCall} = get_top_n_info(Item),
+            {Memory, MsgQueueLen} = get_pid_info(Pid, [memory, message_queue_len]),
+            Format = get_rank_format(reductions, ChoosePos, Pos, NameWidth, CurrentWidth),
+            R = io_lib:format(
+                Format,
+                [
+                    Pos,
+                    pid_to_list(Pid),
+                    observer_cli_lib:to_list(Reductions),
+                    NameOrCall,
+                    observer_cli_lib:to_byte(Memory),
+                    observer_cli_lib:to_list(MsgQueueLen),
+                    CurFun
+                ]
+            ),
+            {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
+        end,
     {Rows, PidList} = top_n_rows(FormatFunc, Start, lists:sublist(ReductionList, Start, Num)),
     {PidList, [Title | lists:reverse(Rows)]};
-render_top_n_view(total_heap_size, HeapList, Num, Pages, Page) ->
-    Title = ?render([
-        ?W2(?GRAY_BG, "No | Pid", 16),
-        ?W2(?RED_BG, " TotalHeapSize", 14),
-        ?W(?GRAY_BG, "Name|>Label|>Initial Call", 45),
-        ?W(?GRAY_BG, "    Reductions", 14),
-        ?W(?GRAY_BG, " MsgQueue", 10),
-        ?W(?GRAY_BG, "Current Function", 32)
-    ]),
+render_top_n_view(total_heap_size, HeapList, Num, Pages, Page, LayoutWidth) ->
+    {NameWidth, CurrentTitleWidth, CurrentWidth} = top_n_text_widths(45, 32, 33, LayoutWidth),
+    Title =
+        ?render([
+            ?W2(?GRAY_BG, "No | Pid", 16),
+            ?W2(?RED_BG, " TotalHeapSize", 14),
+            ?W(?GRAY_BG, "Name|>Label|>Initial Call", NameWidth),
+            ?W(?GRAY_BG, "    Reductions", 14),
+            ?W(?GRAY_BG, " MsgQueue", 10),
+            ?W(?GRAY_BG, "Current Function", CurrentTitleWidth)
+        ]),
     {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(HeapList)),
-    FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
-        {Pid, HeapSize, CurFun, NameOrCall} = get_top_n_info(Item),
-        {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
-        Format = get_rank_format(total_heap_size, ChoosePos, Pos),
-        R = io_lib:format(
-            Format,
-            [
-                Pos,
-                pid_to_list(Pid),
-                observer_cli_lib:to_byte(HeapSize),
-                NameOrCall,
-                observer_cli_lib:to_list(Reductions),
-                observer_cli_lib:to_list(MsgQueueLen),
-                CurFun
-            ]
-        ),
-        {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
-    end,
+    FormatFunc =
+        fun(Item, {Acc, Acc1, Pos}) ->
+            {Pid, HeapSize, CurFun, NameOrCall} = get_top_n_info(Item),
+            {Reductions, MsgQueueLen} = get_pid_info(Pid, [reductions, message_queue_len]),
+            Format = get_rank_format(total_heap_size, ChoosePos, Pos, NameWidth, CurrentWidth),
+            R = io_lib:format(
+                Format,
+                [
+                    Pos,
+                    pid_to_list(Pid),
+                    observer_cli_lib:to_byte(HeapSize),
+                    NameOrCall,
+                    observer_cli_lib:to_list(Reductions),
+                    observer_cli_lib:to_list(MsgQueueLen),
+                    CurFun
+                ]
+            ),
+            {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
+        end,
     {Rows, PidList} = top_n_rows(FormatFunc, Start, lists:sublist(HeapList, Start, Num)),
     {PidList, [Title | lists:reverse(Rows)]};
-render_top_n_view(message_queue_len, MQLenList, Num, Pages, Page) ->
-    Title = ?render([
-        ?W2(?GRAY_BG, "No | Pid", 16),
-        ?W2(?RED_BG, " MsgQueue", 11),
-        ?W(?GRAY_BG, "Name|>Label|>Initial Call", 44),
-        ?W(?GRAY_BG, "      Memory", 13),
-        ?W(?GRAY_BG, "    Reductions", 14),
-        ?W(?GRAY_BG, "Current Function", 33)
-    ]),
+render_top_n_view(message_queue_len, MQLenList, Num, Pages, Page, LayoutWidth) ->
+    {NameWidth, CurrentTitleWidth, CurrentWidth} = top_n_text_widths(44, 33, 34, LayoutWidth),
+    Title =
+        ?render([
+            ?W2(?GRAY_BG, "No | Pid", 16),
+            ?W2(?RED_BG, " MsgQueue", 11),
+            ?W(?GRAY_BG, "Name|>Label|>Initial Call", NameWidth),
+            ?W(?GRAY_BG, "      Memory", 13),
+            ?W(?GRAY_BG, "    Reductions", 14),
+            ?W(?GRAY_BG, "Current Function", CurrentTitleWidth)
+        ]),
     {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(MQLenList)),
-    FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
-        {Pid, MQLen, CurFun, NameOrCall} = get_top_n_info(Item),
-        {Reductions, Memory} = get_pid_info(Pid, [reductions, memory]),
-        Format = get_rank_format(message_queue_len, ChoosePos, Pos),
-        R = io_lib:format(
-            Format,
-            [
-                Pos,
-                pid_to_list(Pid),
-                observer_cli_lib:to_list(MQLen),
-                NameOrCall,
-                observer_cli_lib:to_byte(Memory),
-                observer_cli_lib:to_list(Reductions),
-                CurFun
-            ]
-        ),
-        {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
-    end,
+    FormatFunc =
+        fun(Item, {Acc, Acc1, Pos}) ->
+            {Pid, MQLen, CurFun, NameOrCall} = get_top_n_info(Item),
+            {Reductions, Memory} = get_pid_info(Pid, [reductions, memory]),
+            Format = get_rank_format(message_queue_len, ChoosePos, Pos, NameWidth, CurrentWidth),
+            R = io_lib:format(
+                Format,
+                [
+                    Pos,
+                    pid_to_list(Pid),
+                    observer_cli_lib:to_list(MQLen),
+                    NameOrCall,
+                    observer_cli_lib:to_byte(Memory),
+                    observer_cli_lib:to_list(Reductions),
+                    CurFun
+                ]
+            ),
+            {[R | Acc], [{Pos, Pid} | Acc1], Pos + 1}
+        end,
     {Rows, PidList} = top_n_rows(FormatFunc, Start, lists:sublist(MQLenList, Start, Num)),
     {PidList, [Title | lists:reverse(Rows)]}.
 
@@ -714,30 +814,79 @@ top_n_rows(FormatFunc, Start, List) ->
     {Row, PidList, _} = lists:foldl(FormatFunc, {[], [], Start}, List),
     {Row, PidList}.
 
-notify_pause_status() ->
-    ?output("\e[31;1m PAUSE  INPUT (p, r/rr, b/bb, h/hh, m/mm) to resume or q to quit \e[0m\n").
+top_n_text_widths(NameWidth, CurrentTitleWidth, CurrentWidth, LayoutWidth) ->
+    Extra = erlang:max(LayoutWidth - (?COLUMN + 5), 0),
+    NameExtra = Extra div 2,
+    CurrentExtra = Extra - NameExtra,
+    {NameWidth + NameExtra, CurrentTitleWidth + CurrentExtra, CurrentWidth + CurrentExtra}.
 
-get_rank_format(Type, Pos, RankPos) ->
-    MemSelected = "|\e[42m~-3.3w|~-12.12s|~13.13s |~-45.45s|~14.14s| ~-9.9s|~-33.33s\e[49m|~n",
-    MemNormal = "|~-3.3w|~-12.12s|~13.13s |~-45.45s|~14.14s| ~-9.9s|~-33.33s|~n",
-    RedSelected =
-        "|\e[42m~-3.3w|~-12.12s|~-15.15s|~-45.45s|~12.12s| ~-9.9s|~-34.34s\e[49m|~n",
-    RedNormal = "|~-3.3w|~-12.12s|~-15.15s|~-45.45s|~12.12s| ~-9.9s|~-34.34s|~n",
-    MqSelected =
-        "|\e[42m~-3.3w|~-12.12s|~-11.11s|~-44.44s|~13.13s| ~-13.13s|~-34.34s\e[49m|~n",
-    MqNormal = "|~-3.3w|~-12.12s|~-11.11s|~-44.44s|~13.13s| ~-13.13s|~-34.34s|~n",
+notify_pause_status() ->
+    ?output(
+        "\e[31;1m PAUSE  INPUT (p, r/rr, b/bb, h/hh, m/mm) to resume "
+        "or q to quit \e[0m\n"
+    ).
+
+get_rank_format(Type, Pos, RankPos, NameWidth, CurrentWidth) ->
     {SelectedFormat, NormalFormat} =
         case Type of
-            memory -> {MemSelected, MemNormal};
-            binary_memory -> {MemSelected, MemNormal};
-            total_heap_size -> {MemSelected, MemNormal};
-            reductions -> {RedSelected, RedNormal};
-            message_queue_len -> {MqSelected, MqNormal}
+            memory ->
+                rank_format("~13.13s ", "~14.14s", " ~-9.9s", NameWidth, CurrentWidth);
+            binary_memory ->
+                rank_format("~13.13s ", "~14.14s", " ~-9.9s", NameWidth, CurrentWidth);
+            total_heap_size ->
+                rank_format("~13.13s ", "~14.14s", " ~-9.9s", NameWidth, CurrentWidth);
+            reductions ->
+                rank_format("~-15.15s", "~12.12s", " ~-9.9s", NameWidth, CurrentWidth);
+            message_queue_len ->
+                rank_format("~-11.11s", "~13.13s", " ~-13.13s", NameWidth, CurrentWidth)
         end,
     case Pos =:= RankPos of
-        true -> SelectedFormat;
-        false -> NormalFormat
+        true ->
+            SelectedFormat;
+        false ->
+            NormalFormat
     end.
+
+rank_format(ValueFormat, MidFormat, QueueFormat, NameWidth, CurrentWidth) ->
+    NameBin = integer_to_list(NameWidth),
+    CurrentBin = integer_to_list(CurrentWidth),
+    Normal =
+        [
+            "|~-3.3w|~-12.12s|",
+            ValueFormat,
+            "|~-",
+            NameBin,
+            ".",
+            NameBin,
+            "s|",
+            MidFormat,
+            "|",
+            QueueFormat,
+            "|~-",
+            CurrentBin,
+            ".",
+            CurrentBin,
+            "s|~n"
+        ],
+    Selected =
+        [
+            "|\e[42m~-3.3w|~-12.12s|",
+            ValueFormat,
+            "|~-",
+            NameBin,
+            ".",
+            NameBin,
+            "s|",
+            MidFormat,
+            "|",
+            QueueFormat,
+            "|~-",
+            CurrentBin,
+            ".",
+            CurrentBin,
+            "s\e[49m|~n"
+        ],
+    {lists:flatten(Selected), lists:flatten(Normal)}.
 
 refresh_next_time(proc_count, Type, Interval) ->
     erlang:send_after(Interval, self(), {proc_count, Type});
@@ -756,25 +905,33 @@ get_port_proc_info(PortLimit, ProcLimit) ->
     ProcCountStr = [integer_to_list(ProcCount), "/", integer_to_list(ProcLimit)],
     PortWarning =
         case PortCount > PortLimit * ?COUNT_ALARM_THRESHOLD of
-            true -> ?RED;
-            false -> <<"">>
+            true ->
+                ?RED;
+            false ->
+                <<"">>
         end,
     ProcWarning =
         case ProcCount > ProcLimit * ?COUNT_ALARM_THRESHOLD of
-            true -> ?RED;
-            false -> <<"">>
+            true ->
+                ?RED;
+            false ->
+                <<"">>
         end,
     {PortWarning, ProcWarning, PortCountStr, ProcCountStr}.
 
 format_atom_info(AtomLimit, AtomCount) ->
     Atom = [integer_to_list(AtomCount), "/", integer_to_list(AtomLimit)],
     case AtomCount > AtomLimit * ?COUNT_ALARM_THRESHOLD of
-        true -> {?RED, Atom};
-        false -> {<<"">>, Atom}
+        true ->
+            {?RED, Atom};
+        false ->
+            {<<"">>, Atom}
     end.
 
-warning_color(Percent) when Percent >= ?CPU_ALARM_THRESHOLD -> ?RED;
-warning_color(_Percent) -> ?GREEN.
+warning_color(Percent) when Percent >= ?CPU_ALARM_THRESHOLD ->
+    ?RED;
+warning_color(_Percent) ->
+    ?GREEN.
 
 process_bar_format_style(Percents, IsLastLine) ->
     Format =
@@ -792,8 +949,10 @@ process_bar_format_style(Percents, IsLastLine) ->
                     W9/binary, " | ~-3.3w ~s", W10/binary, " | ~-3.3w ~s \e[0m|~n">>
         end,
     case IsLastLine of
-        true -> <<?UNDERLINE/binary, Format/binary>>;
-        false -> Format
+        true ->
+            <<?UNDERLINE/binary, Format/binary>>;
+        false ->
+            Format
     end.
 
 get_top_n_info(Item) ->
@@ -806,8 +965,10 @@ display_unique_flag(IsName, Call, Pid) ->
     case choose_name(IsName) of
         undefined ->
             case choose_label(Pid) of
-                undefined -> choose_call(Call, Pid);
-                Label -> Label
+                undefined ->
+                    choose_call(Call, Pid);
+                Label ->
+                    Label
             end;
         Name ->
             Name
@@ -819,25 +980,30 @@ choose_name(_) ->
     undefined.
 
 choose_label(Pid) ->
-    case
-        erlang:function_exported(proc_lib, get_label, 1) andalso
-            proc_lib:get_label(Pid)
-    of
-        false -> undefined;
-        undefined -> undefined;
-        Label -> io_lib:format("~p", [Label])
+    case erlang:function_exported(proc_lib, get_label, 1) andalso proc_lib:get_label(Pid) of
+        false ->
+            undefined;
+        undefined ->
+            undefined;
+        Label ->
+            io_lib:format("~p", [Label])
     end.
 
 choose_call({proc_lib, init_p, 5}, Pid) ->
     %% translate gen_xxx behavior
-    observer_cli_lib:mfa_to_list(proc_lib:translate_initial_call(Pid));
+    observer_cli_lib:mfa_to_list(
+        proc_lib:translate_initial_call(Pid)
+    );
 choose_call(Call, _Pid) ->
     observer_cli_lib:mfa_to_list(Call).
 
 get_refresh_prompt(proc_count, Type, Interval, Rows) ->
     io_lib:format("recon:proc_count(~p, ~w) Interval:~wms", [Type, Rows, Interval]);
 get_refresh_prompt(proc_window, Type, Interval, Rows) ->
-    io_lib:format("recon:proc_window(~p, ~w, ~w) Interval:~wms", [Type, Rows, Interval, Interval]).
+    io_lib:format(
+        "recon:proc_window(~p, ~w, ~w) Interval:~wms",
+        [Type, Rows, Interval, Interval]
+    ).
 
 get_stable_system_info() ->
     OtpRelease = erlang:system_info(otp_release),
@@ -859,13 +1025,16 @@ get_atom_status() ->
             Count = erlang:system_info(atom_count),
             {ok, Limit, Count}
     catch
-        _:badarg -> {error, unsupported}
+        _:badarg ->
+            {error, unsupported}
     end.
 
 get_pid_info(Pid, Keys) ->
     case recon:info(Pid, Keys) of
-        undefined -> {"dead", "dead"};
-        [{_, Val1}, {_, Val2}] -> {Val1, Val2}
+        undefined ->
+            {"dead", "dead"};
+        [{_, Val1}, {_, Val2}] ->
+            {Val1, Val2}
     end.
 
 get_top_n(proc_window, Type, Interval, Rows, IsFirstTime) when not IsFirstTime ->
@@ -877,8 +1046,19 @@ connect_error(Prompt, Node) ->
     Prop = <<?RED/binary, Prompt/binary, ?RESET/binary>>,
     ?output(Prop, [Node]).
 
-start_process_view(StorePid, RenderPid, Opts = #view_opts{home = Home}, LastSchWallFlag, AutoJump) ->
-    #home{cur_page = CurPage, pages = Pages, scheduler_usage = SchUsage} = Home,
+start_process_view(
+    StorePid,
+    RenderPid,
+    Opts = #view_opts{home = Home},
+    LastSchWallFlag,
+    AutoJump
+) ->
+    #home{
+        cur_page = CurPage,
+        pages = Pages,
+        scheduler_usage = SchUsage
+    } =
+        Home,
     {_, CurPos} = lists:keyfind(CurPage, 1, Pages),
     case observer_cli_store:lookup_pos(StorePid, CurPos) of
         {CurPos, ChoosePid} ->
@@ -891,13 +1071,17 @@ start_process_view(StorePid, RenderPid, Opts = #view_opts{home = Home}, LastSchW
             manager(StorePid, RenderPid, Opts, LastSchWallFlag)
     end.
 
-set_scheduler_wall_time(_Flag, ?DISABLE) -> false;
-set_scheduler_wall_time(Flag, ?ENABLE) -> erlang:system_flag(scheduler_wall_time, Flag).
+set_scheduler_wall_time(_Flag, ?DISABLE) ->
+    false;
+set_scheduler_wall_time(Flag, ?ENABLE) ->
+    erlang:system_flag(scheduler_wall_time, Flag).
 
 check_auto_row() ->
     case io:rows() of
-        {ok, _} -> true;
-        {error, _} -> false
+        {ok, _} ->
+            true;
+        {error, _} ->
+            false
     end.
 
 node_stats({LastIn, LastOut, LastGCs, LastWords, LastScheduleWall}, SchUsage) ->
@@ -922,8 +1106,10 @@ get_incremental_stats(SchUsage) ->
     {GCs, Words, _} = erlang:statistics(garbage_collection),
     ScheduleWall =
         case SchUsage of
-            ?ENABLE -> erlang:statistics(scheduler_wall_time);
-            ?DISABLE -> undefined
+            ?ENABLE ->
+                erlang:statistics(scheduler_wall_time);
+            ?DISABLE ->
+                undefined
         end,
     {In, Out, GCs, Words, ScheduleWall}.
 

--- a/src/observer_cli_application.erl
+++ b/src/observer_cli_application.erl
@@ -8,7 +8,7 @@
 -export([clean/1]).
 
 -ifdef(TEST).
--export([app_status/1, find_group_leader/1, update_app_stats/6]).
+-export([app_status/1, find_group_leader/1, render_app_info/3, update_app_stats/6]).
 -endif.
 
 %% API
@@ -106,37 +106,49 @@ render_app_info(Row, CurPage, {Type, N}) ->
         {_, RedColor},
         {_, MsgQColor}
     ] = lists:keyreplace(Type, 1, InitColor, {Type, ?RED_BG}),
+    [
+        IdTitleW,
+        AppTitleW,
+        ProcessTitleW,
+        MemoryTitleW,
+        ReductionsTitleW,
+        MsgQTitleW,
+        StatusTitleW,
+        VersionTitleW
+    ] =
+        app_title_widths(),
     Title = ?render([
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Id", 3),
+        ?W2(?GRAY_BG, "Id", IdTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "App", 31),
+        ?W2(?GRAY_BG, "App", AppTitleW),
         ?UNDERLINE,
-        ?W2(ProcessColor, "ProcessCount(p)", 20),
+        ?W2(ProcessColor, "ProcessCount(p)", ProcessTitleW),
         ?UNDERLINE,
-        ?W2(MemColor, "Memory(m)", 20),
+        ?W2(MemColor, "Memory(m)", MemoryTitleW),
         ?UNDERLINE,
-        ?W2(RedColor, "Reductions(r)", 17),
+        ?W2(RedColor, "Reductions(r)", ReductionsTitleW),
         ?UNDERLINE,
-        ?W2(MsgQColor, "MsgQ(mq)", 10),
+        ?W2(MsgQColor, "MsgQ(mq)", MsgQTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Status", 12),
+        ?W2(?GRAY_BG, "Status", StatusTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "version", 16)
+        ?W2(?GRAY_BG, "version", VersionTitleW)
     ]),
+    [IdW, AppW, ProcessW, MemoryW, ReductionsW, MsgQW, StatusW, VersionW] = app_row_widths(),
     {_, View} = lists:foldl(
         fun({_, _, Item}, {Pos, Acc}) ->
             [App, C, M, R, Q, S, V] = Item,
             {Pos + 1, [
                 ?render([
-                    ?W(Pos, 2),
-                    ?W(App, 29),
-                    ?W(C, 18),
-                    ?W({byte, M}, 18),
-                    ?W(R, 15),
-                    ?W(Q, 8),
-                    ?W(S, 10),
-                    ?W(V, 15)
+                    ?W(Pos, IdW),
+                    ?W(App, AppW),
+                    ?W(C, ProcessW),
+                    ?W({byte, M}, MemoryW),
+                    ?W(R, ReductionsW),
+                    ?W(Q, MsgQW),
+                    ?W(S, StatusW),
+                    ?W(V, VersionW)
                 ])
                 | Acc
             ]}
@@ -145,6 +157,18 @@ render_app_info(Row, CurPage, {Type, N}) ->
         SortList
     ),
     [Title | lists:reverse(View)].
+
+app_title_widths() ->
+    observer_cli_lib:weighted_widths(
+        [3, 31, 20, 20, 17, 10, 12, 16],
+        [0, 4, 0, 0, 1, 0, 0, 4]
+    ).
+
+app_row_widths() ->
+    observer_cli_lib:weighted_widths(
+        [2, 29, 18, 18, 15, 8, 10, 15],
+        [0, 4, 0, 0, 1, 0, 0, 4]
+    ).
 
 app_info() ->
     Info = application:info(),

--- a/src/observer_cli_ets.erl
+++ b/src/observer_cli_ets.erl
@@ -8,7 +8,7 @@
 -export([clean/1]).
 
 -ifdef(TEST).
--export([get_ets_info/2, is_reg/1, unread/0]).
+-export([get_ets_info/2, is_reg/1, render_ets_info/3, unread/0]).
 -endif.
 
 -define(LAST_LINE,
@@ -87,24 +87,36 @@ render_ets_info(Rows, CurPage, Attr) ->
             memory -> {?RED_BG, ?GRAY_BG};
             _ -> {?GRAY_BG, ?RED_BG}
         end,
+    [
+        NameTitleW,
+        SizeTitleW,
+        MemoryTitleW,
+        TypeTitleW,
+        ProtectionTitleW,
+        KeyPosTitleW,
+        WriteReadTitleW,
+        OwnerTitleW
+    ] =
+        ets_title_widths(),
     Title = ?render([
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Table Name", 37),
+        ?W2(?GRAY_BG, "Table Name", NameTitleW),
         ?UNDERLINE,
-        ?W2(SizeColor, "Size", 14),
+        ?W2(SizeColor, "Size", SizeTitleW),
         ?UNDERLINE,
-        ?W2(MemColor, "    Memory    ", 14),
+        ?W2(MemColor, "    Memory    ", MemoryTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Type", 15),
+        ?W2(?GRAY_BG, "Type", TypeTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Protection", 12),
+        ?W2(?GRAY_BG, "Protection", ProtectionTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "KeyPos", 8),
+        ?W2(?GRAY_BG, "KeyPos", KeyPosTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Write/Read", 14),
+        ?W2(?GRAY_BG, "Write/Read", WriteReadTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Owner Pid", 15)
+        ?W2(?GRAY_BG, "Owner Pid", OwnerTitleW)
     ]),
+    [NameW, SizeW, MemoryW, TypeW, ProtectionW, KeyPosW, WriteReadW, OwnerW] = ets_row_widths(),
     RowView = [
         begin
             Name = proplists:get_value(name, Ets),
@@ -117,19 +129,31 @@ render_ets_info(Rows, CurPage, Attr) ->
             Read = observer_cli_lib:to_list(proplists:get_value(read_concurrency, Ets)),
             Owner = proplists:get_value(owner, Ets),
             ?render([
-                ?W(Name, 36),
-                ?W(Size, 12),
-                ?W({byte, Memory * WordSize}, 12),
-                ?W(Type, 13),
-                ?W(Protect, 10),
-                ?W(KeyPos, 6),
-                ?W(Write ++ "/" ++ Read, 12),
-                ?W(Owner, 14)
+                ?W(Name, NameW),
+                ?W(Size, SizeW),
+                ?W({byte, Memory * WordSize}, MemoryW),
+                ?W(Type, TypeW),
+                ?W(Protect, ProtectionW),
+                ?W(KeyPos, KeyPosW),
+                ?W(Write ++ "/" ++ Read, WriteReadW),
+                ?W(Owner, OwnerW)
             ])
         end
      || {_, _, Ets} <- SortEts
     ],
     [Title | RowView].
+
+ets_title_widths() ->
+    observer_cli_lib:weighted_widths(
+        [37, 14, 14, 15, 12, 8, 14, 15],
+        [4, 1, 1, 0, 0, 0, 0, 4]
+    ).
+
+ets_row_widths() ->
+    observer_cli_lib:weighted_widths(
+        [36, 12, 12, 13, 10, 6, 12, 14],
+        [4, 1, 1, 0, 0, 0, 0, 4]
+    ).
 
 get_ets_info(Tab, Attr) ->
     try ets:info(Tab) of

--- a/src/observer_cli_help.erl
+++ b/src/observer_cli_help.erl
@@ -13,6 +13,7 @@
 -endif.
 
 -define(HELP_COLUMN_WIDTH, 85).
+-define(SHORTCUT_COLUMN_WIDTH, 12).
 
 -spec start(view_opts()) -> no_return().
 start(#view_opts{help = #help{interval = Interval}} = ViewOpts) ->
@@ -60,33 +61,55 @@ render_doc(Text) ->
 
 render_help() ->
     [
-        "|\e[44m1. Start Mode\e[49m \n",
+        "|Doc - Shortcuts and command examples\n",
+        section("1. Start Mode"),
         "| \e[48;2;80;80;80m1.1\e[0m  observer_cli:start(). \n",
         "| \e[48;2;80;80;80m1.2\e[0m  observer_cli:start(Node).\n",
         "| \e[48;2;80;80;80m1.3\e[0m  observer_cli:start(Node, Cookie).\n",
 
-        "|\e[44m2. HOME(H) Commands\e[49m \n",
-        "| \e[48;2;80;80;80m`            \e[0m  enable/disable schedule usage.\n",
-        "| \e[48;2;80;80;80mPageDown     \e[0m  pd or F(forward).\n",
-        "| \e[48;2;80;80;80mPageUp       \e[0m  pu or B(back).\n",
-        "| \e[48;2;80;80;80mr            \e[0m switch mode to reduction(proc_count).\n",
-        "| \e[48;2;80;80;80mrr           \e[0m switch mode to reduction(proc_window).\n",
-        "| \e[48;2;80;80;80mm            \e[0m switch mode to memory(proc_count).\n",
-        "| \e[48;2;80;80;80mmm           \e[0m switch mode to memory(proc_window).\n",
-        "| \e[48;2;80;80;80mb            \e[0m switch mode to bin memory(proc_count).\n",
-        "| \e[48;2;80;80;80mbb           \e[0m switch mode to bin memory(proc_window).\n",
-        "| \e[48;2;80;80;80mmq           \e[0m switch mode to message queue len(proc_count).\n",
-        "| \e[48;2;80;80;80mmmq          \e[0m switch mode to message queue len(proc_window).\n",
-        "| \e[48;2;80;80;80mt            \e[0m switch mode to total heap size(proc_count).\n",
-        "| \e[48;2;80;80;80mtt           \e[0m switch mode to total heap size(proc_window).\n",
-        "| \e[48;2;80;80;80m3000         \e[0m set interval time to 3000ms, the integer must >= 1500.\n",
-        "| \e[48;2;80;80;80m13           \e[0m choose the 13th process(green line), the integer must in top list.\n",
-        "| \e[48;2;80;80;80m<0.43.0>     \e[0m choose the <0.43.0> process, the pid does not need to be in the top list.\n",
-        "| \e[48;2;80;80;80m<431 or >431 \e[0m choose the <0.431.0> process, the pid does not need to be in the top list.\n",
-        "| \e[48;2;80;80;80mp            \e[0m pause/unpause the view.\n",
+        section("2. Global Commands"),
+        shortcut("PageDown", "pd or F(forward)."),
+        shortcut("PageUp", "pu or B(back)."),
+        shortcut("3000", "set interval time to 3000ms, the integer must >= 1500."),
+        shortcut("p", "pause/unpause the view."),
 
-        "|\e[44m5. Reference\e[49m \n",
+        section("3. HOME(H) Commands"),
+        shortcut("`", "enable/disable schedule usage."),
+        shortcut("r", "switch mode to reduction(proc_count)."),
+        shortcut("rr", "switch mode to reduction(proc_window)."),
+        shortcut("m", "switch mode to memory(proc_count)."),
+        shortcut("mm", "switch mode to memory(proc_window)."),
+        shortcut("b", "switch mode to bin memory(proc_count)."),
+        shortcut("bb", "switch mode to bin memory(proc_window)."),
+        shortcut("mq", "switch mode to message queue len(proc_count)."),
+        shortcut("mmq", "switch mode to message queue len(proc_window)."),
+        shortcut("t", "switch mode to total heap size(proc_count)."),
+        shortcut("tt", "switch mode to total heap size(proc_window)."),
+
+        section("4. Process Select Examples"),
+        shortcut("13", "choose the 13th process(green line), the integer must in top list."),
+        shortcut(
+            "<0.43.0>", "choose the <0.43.0> process, the pid does not need to be in the top list."
+        ),
+        shortcut(
+            "<431 or >431",
+            "choose the <0.431.0> process, the pid does not need to be in the top list."
+        ),
+
+        section("5. Reference"),
         "|More information about recon:proc_count/2 and recon:proc_window/3 \n",
         "|refer to https://github.com/ferd/recon/blob/master/src/recon.erl  \n",
         "|Any issue please visit: https://github.com/zhongwencool/observer_cli/issues  \n"
+    ].
+
+section(Text) ->
+    ["|\e[44m", Text, "\e[49m \n"].
+
+shortcut(Key, Desc) ->
+    [
+        "| \e[48;2;80;80;80m",
+        io_lib:format("~-*s", [?SHORTCUT_COLUMN_WIDTH, Key]),
+        "\e[0m ",
+        Desc,
+        "\n"
     ].

--- a/src/observer_cli_inet.erl
+++ b/src/observer_cli_inet.erl
@@ -127,17 +127,27 @@ render_worker(StorePid, InetOpt, LastTimeRef, Count, LastIO, AutoRow) ->
 
 render_io_rows({LastIn, LastOut}) ->
     {{input, In}, {output, Out}} = erlang:statistics(io),
+    [
+        ByteInputW,
+        InputDeltaW,
+        ByteOutputW,
+        OutputDeltaW,
+        TotalInputW,
+        TotalInW,
+        TotalOutputW,
+        TotalOutW
+    ] = io_widths(),
     {
         ?render([
             ?YELLOW,
-            ?W("Byte Input", 14),
-            ?W({byte, In - LastIn}, 12),
-            ?W("Byte Output", 13),
-            ?W({byte, Out - LastOut}, 12),
-            ?W("Total Input", 15),
-            ?W({byte, In}, 17),
-            ?W("Total Output", 15),
-            ?W({byte, Out}, 17)
+            ?W("Byte Input", ByteInputW),
+            ?W({byte, In - LastIn}, InputDeltaW),
+            ?W("Byte Output", ByteOutputW),
+            ?W({byte, Out - LastOut}, OutputDeltaW),
+            ?W("Total Input", TotalInputW),
+            ?W({byte, In}, TotalInW),
+            ?W("Total Output", TotalOutputW),
+            ?W({byte, Out}, TotalOutW)
         ]),
         {In, Out}
     }.
@@ -160,6 +170,8 @@ render_inet_rows(InetList, Num, #inet{
 }) when Type =:= cnt orelse Type =:= oct ->
     {Unit, RecvType, SendType} = trans_type(Type),
     Title = title(Type, RecvType, SendType),
+    [NoW, PortW, ValueW, RecvW, SendW, OutputW, InputW, QueueW, MemoryW, PeerW] =
+        inet_widths(),
     {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(InetList)),
     FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
         {Port, Value, [{_, Recv}, {_, Send}]} = Item,
@@ -170,18 +182,20 @@ render_inet_rows(InetList, Num, #inet{
         QueueSize = proplists:get_value(queue_size, MemoryUsed),
         Memory = proplists:get_value(memory, MemoryUsed),
         IP = get_remote_ip(Port),
-        {ValueFormat, RecvFormat, SendFormat} = trans_format(Unit, Value, Recv, Send),
+        {ValueFormat, RecvFormat, SendFormat} = trans_format(
+            Unit, Value, Recv, Send, [ValueW, RecvW, SendW]
+        ),
         R = [
-            ?W(Pos, 2),
-            ?W(Port, 16),
+            ?W(Pos, NoW),
+            ?W(Port, PortW),
             ValueFormat,
             RecvFormat,
             SendFormat,
-            ?W({byte, Output}, 12),
-            ?W({byte, Input}, 12),
-            ?W(QueueSize, 6),
-            ?W({byte, Memory}, 12),
-            ?W(IP, 19)
+            ?W({byte, Output}, OutputW),
+            ?W({byte, Input}, InputW),
+            ?W(QueueSize, QueueW),
+            ?W({byte, Memory}, MemoryW),
+            ?W(IP, PeerW)
         ],
         Rows = add_choose_color(ChoosePos, Pos, R),
         {[?render(Rows) | Acc], [{Pos, Port} | Acc1], Pos + 1}
@@ -195,6 +209,8 @@ render_inet_rows(InetList, Num, #inet{
 render_inet_rows(InetList, Num, #inet{type = Type, pages = Pages, cur_page = Page}) ->
     {Unit, Type1, Type2} = trans_type(Type),
     Title = title(Type, Type1, Type2),
+    [NoW, PortW, ValueW, Type1W, Type2W, OutputW, InputW, QueueW, MemoryW, PeerW] =
+        inet_widths(),
     {Start, ChoosePos} = observer_cli_lib:get_pos(Page, Num, Pages, erlang:length(InetList)),
     FormatFunc = fun(Item, {Acc, Acc1, Pos}) ->
         {Port, Value, _} = Item,
@@ -211,18 +227,20 @@ render_inet_rows(InetList, Num, #inet{type = Type, pages = Pages, cur_page = Pag
                 true -> Value + Packet1;
                 false -> Value
             end,
-        {ValueFormat, Packet1Format, AllFormat} = trans_format(Unit, Value, Packet1, AllPacket),
+        {ValueFormat, Packet1Format, AllFormat} = trans_format(
+            Unit, Value, Packet1, AllPacket, [ValueW, Type1W, Type2W]
+        ),
         R = [
-            ?W(Pos, 2),
-            ?W(Port, 16),
+            ?W(Pos, NoW),
+            ?W(Port, PortW),
             ValueFormat,
             Packet1Format,
             AllFormat,
-            ?W({byte, Input}, 12),
-            ?W({byte, Output}, 12),
-            ?W(QueueSize, 6),
-            ?W({byte, Memory}, 12),
-            ?W(IP, 19)
+            ?W({byte, Input}, OutputW),
+            ?W({byte, Output}, InputW),
+            ?W(QueueSize, QueueW),
+            ?W({byte, Memory}, MemoryW),
+            ?W(IP, PeerW)
         ],
         Rows = add_choose_color(ChoosePos, Pos, R),
         {[?render(Rows) | Acc], [{Pos, Port} | Acc1], Pos + 1}
@@ -276,6 +294,7 @@ trans_type(send_oct) ->
 trans_type(recv_oct) ->
     {byte, "send_oct", "oct"}.
 
+-ifdef(TEST).
 trans_format(byte, Val, Val1, Val2) ->
     {
         ?W({byte, Val}, 10),
@@ -288,22 +307,50 @@ trans_format(number, Val, Val1, Val2) ->
         ?W(Val1, 10),
         ?W(Val2, 10)
     }.
+-endif.
+
+trans_format(byte, Val, Val1, Val2, [ValW, Val1W, Val2W]) ->
+    {
+        ?W({byte, Val}, ValW),
+        ?W({byte, Val1}, Val1W),
+        ?W({byte, Val2}, Val2W)
+    };
+trans_format(number, Val, Val1, Val2, [ValW, Val1W, Val2W]) ->
+    {
+        ?W(Val, ValW),
+        ?W(Val1, Val1W),
+        ?W(Val2, Val2W)
+    }.
 
 title(Type, Type1, Type2) ->
+    [NoW, PortW, TypeW, Type1W, Type2W, OutputW, InputW, QueueW, MemoryW, PeerW] =
+        inet_widths(),
     ?render([
         ?UNDERLINE,
         ?GRAY_BG,
-        ?W("NO", 2),
-        ?W("Port", 16),
-        ?W(erlang:atom_to_list(Type), 10),
-        ?W(Type1, 10),
-        ?W(Type2, 10),
-        ?W("output", 12),
-        ?W("input", 12),
-        ?W("queuesize", 6),
-        ?W("memory", 12),
-        ?W("Peername(ip:port)", 19)
+        ?W("NO", NoW),
+        ?W("Port", PortW),
+        ?W(erlang:atom_to_list(Type), TypeW),
+        ?W(Type1, Type1W),
+        ?W(Type2, Type2W),
+        ?W("output", OutputW),
+        ?W("input", InputW),
+        ?W("queuesize", QueueW),
+        ?W("memory", MemoryW),
+        ?W("Peername(ip:port)", PeerW)
     ]).
+
+io_widths() ->
+    observer_cli_lib:weighted_widths(
+        [14, 12, 13, 12, 15, 17, 15, 17],
+        [0, 1, 0, 1, 0, 1, 0, 1]
+    ).
+
+inet_widths() ->
+    observer_cli_lib:weighted_widths(
+        [2, 16, 10, 10, 10, 12, 12, 6, 12, 19],
+        [0, 3, 3, 3, 3, 1, 1, 0, 1, 4]
+    ).
 
 get_remote_ip(P) ->
     case inet:peername(P) of

--- a/src/observer_cli_lib.erl
+++ b/src/observer_cli_lib.erl
@@ -17,10 +17,14 @@
 -export([next_redraw/2]).
 -export([flush_redraw_timer/1]).
 -export([render_menu/2]).
+-export([layout_width/0]).
+-export([layout_extra_width/0]).
+-export([weighted_widths/2]).
 -export([get_terminal_rows/1]).
 -export([select/1]).
 -export([unselect/1]).
 -export([parse_integer/1]).
+-export([pad_rendered/1]).
 -export([render_last_line/1]).
 -export([exit_processes/1]).
 -export([update_page_pos/3]).
@@ -31,6 +35,7 @@
 
 -ifdef(TEST).
 -export([parse_cmd_str/1]).
+-export([visible_length/1]).
 -endif.
 
 -spec uptime() -> list().
@@ -116,7 +121,7 @@ mfa_to_list(Function) ->
 -spec render(list()) -> iolist().
 render(FA) ->
     {F, A} = tidy_format_args([" \e[0m|~n" | lists:reverse(["|" | FA])], true, [], []),
-    io_lib:format(erlang:iolist_to_binary(F), A).
+    pad_rendered(io_lib:format(erlang:iolist_to_binary(F), A)).
 
 %{erlang:iolist_to_binary(F), A}.
 
@@ -129,7 +134,7 @@ render_menu(Type, Text) ->
         end,
     Title = get_menu_title(Type, MnesiaTitle),
     UpTime = uptime(),
-    TitleWidth = ?COLUMN + 151 - erlang:length(UpTime),
+    TitleWidth = ?COLUMN + 151 - erlang:length(UpTime) + layout_extra_width(),
     ?render([?W([Title | Text], TitleWidth) | UpTime]).
 
 tidy_format_args([], _NeedLine, FAcc, AAcc) ->
@@ -315,6 +320,108 @@ flush_redraw_timer(LastTimeRef) ->
     LastTimeRef =/= ?INIT_TIME_REF andalso erlang:cancel_timer(LastTimeRef),
     ok.
 
+-spec layout_width() -> pos_integer().
+layout_width() ->
+    case io:columns() of
+        {ok, Columns} when is_integer(Columns), Columns > ?COLUMN + 5 ->
+            Columns - 1;
+        {ok, Columns} when is_integer(Columns) ->
+            erlang:max(?COLUMN + 5, Columns);
+        _ ->
+            ?COLUMN + 5
+    end.
+
+-spec layout_extra_width() -> non_neg_integer().
+layout_extra_width() ->
+    layout_width() - (?COLUMN + 5).
+
+-spec weighted_widths([non_neg_integer()], [non_neg_integer()]) -> [non_neg_integer()].
+weighted_widths(BaseWidths, Weights) when length(BaseWidths) =:= length(Weights) ->
+    Extras = weighted_extras(layout_extra_width(), Weights),
+    [Width + Extra || {Width, Extra} <- lists:zip(BaseWidths, Extras)].
+
+weighted_extras(_Extra, []) ->
+    [];
+weighted_extras(Extra, Weights) ->
+    case lists:sum(Weights) of
+        0 ->
+            [0 || _ <- Weights];
+        Total ->
+            Base = [(Extra * Weight) div Total || Weight <- Weights],
+            add_extra_remainder(Base, Weights, Extra - lists:sum(Base))
+    end.
+
+add_extra_remainder(Widths, _Weights, 0) ->
+    Widths;
+add_extra_remainder([], [], _Rem) ->
+    [];
+add_extra_remainder([Width | Widths], [0 | Weights], Rem) ->
+    [Width | add_extra_remainder(Widths, Weights, Rem)];
+add_extra_remainder([Width | Widths], [_Weight | Weights], Rem) ->
+    [Width + 1 | add_extra_remainder(Widths, Weights, Rem - 1)].
+
+-spec pad_rendered(iodata()) -> list().
+pad_rendered(IoData) ->
+    Lines = binary:split(unicode:characters_to_binary(IoData), <<"\n">>, [global]),
+    unicode:characters_to_list(iolist_to_binary(join_lines([pad_line(Line) || Line <- Lines]))).
+
+join_lines([]) ->
+    <<>>;
+join_lines([Line]) ->
+    Line;
+join_lines([Line | Rest]) ->
+    [Line, <<"\n">> | join_lines(Rest)].
+
+pad_line(<<>>) ->
+    <<>>;
+pad_line(Line) ->
+    NormalizedLine = trim_border_space(Line),
+    case border_parts(NormalizedLine) of
+        {Body, Suffix} -> pad_bordered_line(NormalizedLine, Body, Suffix);
+        false -> NormalizedLine
+    end.
+
+trim_border_space(Line) ->
+    Reset = ?RESET,
+    Suffix = <<$|, $\s, Reset/binary>>,
+    case take_suffix(Line, Suffix) of
+        {Body, _} -> <<Body/binary, $|, Reset/binary>>;
+        false -> Line
+    end.
+
+border_parts(Line) ->
+    Reset = ?RESET,
+    ResetSuffix = <<$|, Reset/binary>>,
+    case take_suffix(Line, <<"|">>) of
+        {Body, Suffix} ->
+            {Body, Suffix};
+        false ->
+            take_suffix(Line, ResetSuffix)
+    end.
+
+take_suffix(Line, Suffix) when byte_size(Line) >= byte_size(Suffix) ->
+    BodySize = byte_size(Line) - byte_size(Suffix),
+    case Line of
+        <<Body:BodySize/binary, Suffix/binary>> -> {Body, Suffix};
+        _ -> false
+    end;
+take_suffix(_Line, _Suffix) ->
+    false.
+
+pad_bordered_line(Line, Body, Suffix) ->
+    case layout_width() - visible_length(Line) of
+        Padding when Padding > 0 ->
+            [Body, lists:duplicate(Padding, $\s), Suffix];
+        _ ->
+            Line
+    end.
+
+visible_length(IoData) ->
+    Bin = unicode:characters_to_binary(IoData),
+    Clean0 = re:replace(Bin, <<"\e\\[[0-9;]*[A-Za-z]">>, <<>>, [global, {return, binary}]),
+    Clean = binary:replace(Clean0, [<<"\n">>, <<"\r">>], <<>>, [global]),
+    length(unicode:characters_to_list(Clean)).
+
 -spec get_terminal_rows(boolean()) -> integer().
 get_terminal_rows(_AutoRow = false) ->
     application:get_env(observer_cli, default_row_size, 30);
@@ -340,9 +447,9 @@ parse_integer(Number) ->
             end
     end.
 
--spec render_last_line(string()) -> list().
+-spec render_last_line(iodata()) -> list().
 render_last_line(Text) ->
-    ?render([?UNDERLINE, ?GRAY_BG, ?W(Text, ?COLUMN + 2)]).
+    ?render([?UNDERLINE, ?GRAY_BG, ?W(Text, layout_width() - 3)]).
 
 -spec exit_processes(list()) -> ok.
 exit_processes(List) ->

--- a/src/observer_cli_mnesia.erl
+++ b/src/observer_cli_mnesia.erl
@@ -6,7 +6,7 @@
 -export([clean/1]).
 
 -ifdef(TEST).
--export([get_table_list/2, with_storage_type/3]).
+-export([get_table_list/2, render_mnesia/4, with_storage_type/3]).
 -endif.
 
 -include("observer_cli.hrl").
@@ -108,24 +108,37 @@ render_mnesia(MnesiaList, Attr, Rows, CurPage) ->
             memory -> {?RED_BG, ?GRAY_BG};
             _ -> {?GRAY_BG, ?RED_BG}
         end,
+    [
+        NameTitleW,
+        MemoryTitleW,
+        SizeTitleW,
+        TypeTitleW,
+        StorageTitleW,
+        OwnerTitleW,
+        IndexTitleW,
+        RegNameTitleW
+    ] =
+        mnesia_title_widths(),
     Title = ?render([
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Name", 25),
+        ?W2(?GRAY_BG, "Name", NameTitleW),
         ?UNDERLINE,
-        ?W2(MemColor, "    Memory    ", 16),
+        ?W2(MemColor, "    Memory    ", MemoryTitleW),
         ?UNDERLINE,
-        ?W2(SizeColor, "Size", 16),
+        ?W2(SizeColor, "Size", SizeTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Type", 12),
+        ?W2(?GRAY_BG, "Type", TypeTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Storage", 15),
+        ?W2(?GRAY_BG, "Storage", StorageTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Owner", 14),
+        ?W2(?GRAY_BG, "Owner", OwnerTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Index", 11),
+        ?W2(?GRAY_BG, "Index", IndexTitleW),
         ?UNDERLINE,
-        ?W2(?GRAY_BG, "Reg_name", 20)
+        ?W2(?GRAY_BG, "Reg_name", RegNameTitleW)
     ]),
+    [NameW, MemoryW, SizeW, TypeW, StorageW, OwnerW, IndexW, RegNameW] =
+        mnesia_row_widths(),
     View = [
         begin
             Name = proplists:get_value(name, Mnesia),
@@ -137,19 +150,31 @@ render_mnesia(MnesiaList, Attr, Rows, CurPage) ->
             Owner = proplists:get_value(owner, Mnesia),
             Storage = proplists:get_value(storage, Mnesia),
             ?render([
-                ?W(Name, 24),
-                ?W({byte, Memory}, 14),
-                ?W(Size, 14),
-                ?W(Type, 10),
-                ?W(Storage, 13),
-                ?W(Owner, 12),
-                ?W(Index, 9),
-                ?W(RegName, 19)
+                ?W(Name, NameW),
+                ?W({byte, Memory}, MemoryW),
+                ?W(Size, SizeW),
+                ?W(Type, TypeW),
+                ?W(Storage, StorageW),
+                ?W(Owner, OwnerW),
+                ?W(Index, IndexW),
+                ?W(RegName, RegNameW)
             ])
         end
      || {_, _, Mnesia} <- SortMnesia
     ],
     [Title | View].
+
+mnesia_title_widths() ->
+    observer_cli_lib:weighted_widths(
+        [25, 16, 16, 12, 15, 14, 11, 20],
+        [4, 0, 0, 0, 1, 1, 0, 4]
+    ).
+
+mnesia_row_widths() ->
+    observer_cli_lib:weighted_widths(
+        [24, 14, 14, 10, 13, 12, 9, 19],
+        [4, 0, 0, 0, 1, 1, 0, 4]
+    ).
 
 mnesia_tables() ->
     [

--- a/src/observer_cli_port.erl
+++ b/src/observer_cli_port.erl
@@ -122,38 +122,41 @@ render_port_info(#{
             true -> ?RED;
             false -> ?GREEN
         end,
+    [Attr1W, Value1W, Attr2W, Value2W, Attr3W, Value3W] =
+        port_info_widths([18, 20, 18, 20, 19, 21]),
     Title =
         ?render([
             ?GRAY_BG,
-            ?W("Attr", 18),
-            ?W("Value", 20),
-            ?W("Attr", 18),
-            ?W("Value", 20),
-            ?W("Attr", 19),
-            ?W("Value", 21)
+            ?W("Attr", Attr1W),
+            ?W("Value", Value1W),
+            ?W("Attr", Attr2W),
+            ?W("Value", Value2W),
+            ?W("Attr", Attr3W),
+            ?W("Value", Value3W)
         ]),
     Rows =
         ?render([
-            ?W("port", 18),
-            ?W(Port, 20),
-            ?W("id", 18),
-            ?W(Id, 20),
-            ?W("name", 19),
-            ?W(Name, 21),
+            ?W("port", Attr1W),
+            ?W(Port, Value1W),
+            ?W("id", Attr2W),
+            ?W(Id, Value2W),
+            ?W("name", Attr3W),
+            ?W(Name, Value3W),
             ?NEW_LINE,
-            ?W("queue_size", 18),
-            ?W2(QueueSizeColor, QueueSize, 21),
-            ?W(" input", 19),
-            ?W({byte, Input}, 20),
-            ?W("output", 19),
-            ?W({byte, Output}, 21),
+            ?W("queue_size", Attr1W),
+            ?W2(QueueSizeColor, QueueSize, Value1W + 1),
+            " ",
+            ?W("input", Attr2W),
+            ?W({byte, Input}, Value2W),
+            ?W("output", Attr3W),
+            ?W({byte, Output}, Value3W),
             ?NEW_LINE,
-            ?W("connected", 18),
-            ?W(Connected, 20),
-            ?W("memory", 18),
-            ?W({byte, Memory}, 20),
-            ?W("os_pid", 19),
-            ?W(OsPid, 21)
+            ?W("connected", Attr1W),
+            ?W(Connected, Value1W),
+            ?W("memory", Attr2W),
+            ?W({byte, Memory}, Value2W),
+            ?W("os_pid", Attr3W),
+            ?W(OsPid, Value3W)
         ]),
     [Title, Rows].
 
@@ -177,12 +180,15 @@ render_link_monitor(Link, Monitors) ->
     ],
     LinkInfo = "Links(" ++ erlang:integer_to_list(erlang:length(Link)) ++ ")",
     MonitorInfo = "Monitors(" ++ erlang:integer_to_list(erlang:length(Monitors)) ++ ")",
+    Extra = observer_cli_lib:layout_extra_width(),
+    ValueW = 110 + Extra + wide_fill(5),
     ?render([
         ?W(LinkInfo, 18),
-        ?W(LinkStr, 110),
+        ?W(LinkStr, ValueW),
         ?NEW_LINE,
-        ?W2(?UNDERLINE, MonitorInfo, 19),
-        ?W2(?UNDERLINE, MonitorsStr, 111)
+        ?UNDERLINE,
+        ?W(MonitorInfo, 18),
+        ?W(MonitorsStr, ValueW)
     ]).
 
 render_type_line(List) ->
@@ -196,12 +202,13 @@ render_type_line(List) ->
             {_, Sock} -> addr_to_str(Sock);
             false -> "undefined"
         end,
+    [SockW, ArrowW, PeerW] = type_line_widths(),
     Line1 =
         ?render([
             ?UNDERLINE,
-            ?W("            " ++ SockName ++ "(sockname)", 55),
-            ?W("<=============>", 15),
-            ?W("            " ++ PeerName ++ "(peername)", 55)
+            ?W("            " ++ SockName ++ "(sockname)", SockW),
+            ?W("<=============>", ArrowW),
+            ?W("            " ++ PeerName ++ "(peername)", PeerW)
         ]),
     Line2 =
         case lists:keyfind(statistics, 1, List) of
@@ -212,6 +219,12 @@ render_type_line(List) ->
         {_, Opts} -> Line2 ++ [render_opts(Opts)];
         false -> Line2
     end.
+
+port_info_widths(Base) ->
+    fill_last(observer_cli_lib:weighted_widths(Base, [0, 1, 0, 1, 0, 3]), wide_fill(5)).
+
+type_line_widths() ->
+    fill_last(observer_cli_lib:weighted_widths([55, 15, 55], [1, 0, 1]), wide_fill(5)).
 
 render_stats(Stats) ->
     RecvOct = proplists:get_value(recv_oct, Stats),
@@ -224,28 +237,41 @@ render_stats(Stats) ->
     SendMax = proplists:get_value(send_max, Stats),
     SendAvg = proplists:get_value(send_avg, Stats),
     SendPend = proplists:get_value(send_pend, Stats),
+    [
+        CntLabelW,
+        CntValueW,
+        OctLabelW,
+        OctValueW,
+        MaxLabelW,
+        MaxValueW,
+        AvgLabelW,
+        AvgValueW,
+        LastLabelW,
+        LastValueW
+    ] =
+        stats_widths(),
     ?render([
-        ?W("recv_cnt", 9),
-        ?W(RecvCnt, 12),
-        ?W("recv_oct", 8),
-        ?W({byte, RecvOct}, 12),
-        ?W("recv_max", 9),
-        ?W({byte, RecvMax}, 12),
-        ?W("recv_avg", 9),
-        ?W({byte, RecvAvg}, 12),
-        ?W("recv_dvi", 9),
-        ?W({byte, RecvDvi}, 12),
+        ?W("recv_cnt", CntLabelW),
+        ?W(RecvCnt, CntValueW),
+        ?W("recv_oct", OctLabelW),
+        ?W({byte, RecvOct}, OctValueW),
+        ?W("recv_max", MaxLabelW),
+        ?W({byte, RecvMax}, MaxValueW),
+        ?W("recv_avg", AvgLabelW),
+        ?W({byte, RecvAvg}, AvgValueW),
+        ?W("recv_dvi", LastLabelW),
+        ?W({byte, RecvDvi}, LastValueW),
         ?NEW_LINE,
-        ?W("send_cnt", 9),
-        ?W(SendCnt, 12),
-        ?W("send_oct", 8),
-        ?W({byte, SendOct}, 12),
-        ?W("send_max", 9),
-        ?W({byte, SendMax}, 12),
-        ?W("send_avg", 9),
-        ?W({byte, SendAvg}, 12),
-        ?W("send_pend", 9),
-        ?W(SendPend, 12)
+        ?W("send_cnt", CntLabelW),
+        ?W(SendCnt, CntValueW),
+        ?W("send_oct", OctLabelW),
+        ?W({byte, SendOct}, OctValueW),
+        ?W("send_max", MaxLabelW),
+        ?W({byte, SendMax}, MaxValueW),
+        ?W("send_avg", AvgLabelW),
+        ?W({byte, SendAvg}, AvgValueW),
+        ?W("send_pend", LastLabelW),
+        ?W(SendPend, LastValueW)
     ]).
 
 render_opts(Opts) ->
@@ -272,76 +298,105 @@ render_opts(Opts) ->
     ReuseAddr = proplists:get_value(reuseaddr, Opts),
     SendTimeout = proplists:get_value(send_timeout, Opts),
     SndBuf = proplists:get_value(sndbuf, Opts),
+    [Option1W, Value1W, Option2W, Value2W, Option3W, Value3W, Option4W, Value4W, Option5W, Value5W] =
+        opts_widths(),
     Title =
         ?render([
             ?GRAY_BG,
-            ?W("Option", 9),
-            ?W("Value", 6),
-            ?W("Option", 14),
-            ?W("Value", 12),
-            ?W("Option", 9),
-            ?W("Value", 12),
-            ?W("Option", 13),
-            ?W("Value", 8),
-            ?W("Option", 9),
-            ?W("Value", 12)
+            ?W("Option", Option1W),
+            ?W("Value", Value1W),
+            ?W("Option", Option2W),
+            ?W("Value", Value2W),
+            ?W("Option", Option3W),
+            ?W("Value", Value3W),
+            ?W("Option", Option4W),
+            ?W("Value", Value4W),
+            ?W("Option", Option5W),
+            ?W("Value", Value5W)
         ]),
     Rows =
         ?render([
-            ?W("mode", 9),
-            ?W(Mode, 6),
-            ?W("recbuf", 14),
-            ?W({byte, RecBuf}, 12),
-            ?W("sndbuf", 9),
-            ?W({byte, SndBuf}, 12),
-            ?W("delay_send", 13),
-            ?W(DelaySend, 8),
-            ?W("dontroute", 9),
-            ?W(DontRoute, 12),
+            ?W("mode", Option1W),
+            ?W(Mode, Value1W),
+            ?W("recbuf", Option2W),
+            ?W({byte, RecBuf}, Value2W),
+            ?W("sndbuf", Option3W),
+            ?W({byte, SndBuf}, Value3W),
+            ?W("delay_send", Option4W),
+            ?W(DelaySend, Value4W),
+            ?W("dontroute", Option5W),
+            ?W(DontRoute, Value5W),
             ?NEW_LINE,
-            ?W("reuseaddr", 9),
-            ?W(ReuseAddr, 6),
-            ?W("packet_size", 14),
-            ?W({byte, PacketSize}, 12),
-            ?W("buffer", 9),
-            ?W({byte, Buffer}, 12),
-            ?W("exit_on_close", 13),
-            ?W(ExitOnClose, 8),
-            ?W("priority", 9),
-            ?W(Priority, 12),
+            ?W("reuseaddr", Option1W),
+            ?W(ReuseAddr, Value1W),
+            ?W("packet_size", Option2W),
+            ?W({byte, PacketSize}, Value2W),
+            ?W("buffer", Option3W),
+            ?W({byte, Buffer}, Value3W),
+            ?W("exit_on_close", Option4W),
+            ?W(ExitOnClose, Value4W),
+            ?W("priority", Option5W),
+            ?W(Priority, Value5W),
             ?NEW_LINE,
-            ?W("active", 9),
-            ?W(Active, 6),
-            ?W("low_watermark", 14),
-            ?W({byte, LowWatermark}, 12),
-            ?W("header", 9),
-            ?W(Header, 12),
-            ?W("keepalive", 13),
-            ?W(KeepAlive, 8),
-            ?W("linger", 9),
-            ?W(Linger, 12),
+            ?W("active", Option1W),
+            ?W(Active, Value1W),
+            ?W("low_watermark", Option2W),
+            ?W({byte, LowWatermark}, Value2W),
+            ?W("header", Option3W),
+            ?W(Header, Value3W),
+            ?W("keepalive", Option4W),
+            ?W(KeepAlive, Value4W),
+            ?W("linger", Option5W),
+            ?W(Linger, Value5W),
             ?NEW_LINE,
-            ?W("nodelay", 9),
-            ?W(NoDelay, 6),
-            ?W("high_watermark", 14),
-            ?W({byte, HighWatermark}, 12),
-            ?W("broadcast", 9),
-            ?W(Broadcast, 12),
-            ?W("send_timeout", 13),
-            ?W(SendTimeout, 8),
-            ?W("packet", 9),
-            ?W(Packet, 12)
+            ?W("nodelay", Option1W),
+            ?W(NoDelay, Value1W),
+            ?W("high_watermark", Option2W),
+            ?W({byte, HighWatermark}, Value2W),
+            ?W("broadcast", Option3W),
+            ?W(Broadcast, Value3W),
+            ?W("send_timeout", Option4W),
+            ?W(SendTimeout, Value4W),
+            ?W("packet", Option5W),
+            ?W(Packet, Value5W)
         ]),
     [Title, Rows].
 
+stats_widths() ->
+    fill_last(
+        observer_cli_lib:weighted_widths([9, 12, 8, 12, 9, 12, 9, 12, 9, 12], [
+            0, 1, 0, 1, 0, 1, 0, 1, 0, 1
+        ]),
+        wide_fill(5)
+    ).
+
+opts_widths() ->
+    fill_last(
+        observer_cli_lib:weighted_widths([9, 6, 14, 12, 9, 12, 13, 8, 9, 12], [
+            0, 1, 0, 2, 0, 2, 0, 1, 0, 2
+        ]),
+        wide_fill(5)
+    ).
+
+wide_fill(Amount) ->
+    case observer_cli_lib:layout_extra_width() of
+        0 -> 0;
+        _ -> Amount
+    end.
+
+fill_last([Last], Amount) ->
+    [Last + Amount];
+fill_last([Width | Rest], Amount) ->
+    [Width | fill_last(Rest, Amount)].
+
 render_last_line() ->
-    io_lib:format("|\e[7mq(quit) ~124.124s\e[0m|~n", [" "]).
+    observer_cli_lib:render_last_line("q(quit)").
 
 render_menu(Type, Interval) ->
     Text = "Interval: " ++ integer_to_list(Interval) ++ "ms",
     Title = get_menu_title(Type),
     UpTime = observer_cli_lib:uptime(),
-    TitleWidth = ?COLUMN + 41 - erlang:length(UpTime),
+    TitleWidth = ?COLUMN + 41 - erlang:length(UpTime) + observer_cli_lib:layout_extra_width(),
     ?render([?W([Title | Text], TitleWidth) | UpTime]).
 
 get_menu_title(Type) ->

--- a/src/observer_cli_process.erl
+++ b/src/observer_cli_process.erl
@@ -20,7 +20,6 @@
     render_reduction_memory/4,
     render_menu/3,
     render_last_line/0,
-    render_footer_line/2,
     state_footer_text/1,
     render_worker/8,
     render_state/3,
@@ -326,45 +325,48 @@ render_process_info(#{
             true -> ?RED;
             false -> ?GREEN
         end,
+    [MetaW, MetaValueW, MemoryW, MemoryValueW, GcW, GcValueW] =
+        process_info_widths([16, 42, 16, 12, 18, 12]),
 
     [
         ?render([
             ?GRAY_BG,
-            ?W("Meta", 16),
-            ?W("Value", 42),
-            ?W("Memory Used", 16),
-            ?W("Value", 12),
-            ?W("Garbage Collection", 18),
-            ?W("Value", 12)
+            ?W("Meta", MetaW),
+            ?W("Value", MetaValueW),
+            ?W("Memory Used", MemoryW),
+            ?W("Value", MemoryValueW),
+            ?W("Garbage Collection", GcW),
+            ?W("Value", GcValueW)
         ]),
         ?render([
-            ?W("registered_name", 16),
-            ?W(Name, 42),
-            ?W("msg_queue_len", 16),
-            ?W2(MessageQueueLenColor, MessageQueueLenStr, 13),
-            ?W(" min_bin_vheap_size", 19),
-            ?W({byte, MinBinVHeapSize}, 12),
+            ?W("registered_name", MetaW),
+            ?W(Name, MetaValueW),
+            ?W("msg_queue_len", MemoryW),
+            ?W2(MessageQueueLenColor, MessageQueueLenStr, MemoryValueW + 1),
+            " ",
+            ?W("min_bin_vheap_size", GcW),
+            ?W({byte, MinBinVHeapSize}, GcValueW),
             ?NEW_LINE,
-            ?W("initial_call", 16),
-            ?W(InitialCallStr, 42),
-            ?W("heap_size", 16),
-            ?W({byte, HeapSize}, 12),
-            ?W("min_heap_size", 18),
-            ?W({byte, MinHeapSize}, 12),
+            ?W("initial_call", MetaW),
+            ?W(InitialCallStr, MetaValueW),
+            ?W("heap_size", MemoryW),
+            ?W({byte, HeapSize}, MemoryValueW),
+            ?W("min_heap_size", GcW),
+            ?W({byte, MinHeapSize}, GcValueW),
             ?NEW_LINE,
-            ?W("group_leader", 16),
-            ?W(GroupLeaderStr, 42),
-            ?W("total_heap_size", 16),
-            ?W({byte, TotalHeapSize}, 12),
-            ?W("fullsweep_after", 18),
-            ?W(FullSweepAfter, 12),
+            ?W("group_leader", MetaW),
+            ?W(GroupLeaderStr, MetaValueW),
+            ?W("total_heap_size", MemoryW),
+            ?W({byte, TotalHeapSize}, MemoryValueW),
+            ?W("fullsweep_after", GcW),
+            ?W(FullSweepAfter, GcValueW),
             ?NEW_LINE,
-            ?W("status", 16),
-            ?W(Status, 42),
-            ?W("trap_exit", 16),
-            ?W(TrapExit, 12),
-            ?W("minor_gcs", 18),
-            ?W(MinorGcs, 12)
+            ?W("status", MetaW),
+            ?W(Status, MetaValueW),
+            ?W("trap_exit", MemoryW),
+            ?W(TrapExit, MemoryValueW),
+            ?W("minor_gcs", GcW),
+            ?W(MinorGcs, GcValueW)
         ])
     ].
 
@@ -399,16 +401,20 @@ render_link_monitor(Link, Monitors, MonitoredBy) ->
     LinkInfo = "Links(" ++ erlang:integer_to_list(erlang:length(Link)) ++ ")",
     MonitorInfo = "Monitors(" ++ erlang:integer_to_list(erlang:length(Monitors)) ++ ")",
     MonitoredByInfo = "MonitoredBy(" ++ erlang:integer_to_list(erlang:length(MonitoredBy)) ++ ")",
+    LinkValueW = 112 + observer_cli_lib:layout_extra_width() + wide_fill(5),
     ?render([
         ?W(LinkInfo, 16),
-        ?W(LinkStr, 112),
+        ?W(LinkStr, LinkValueW),
         ?NEW_LINE,
         ?W(MonitorInfo, 16),
-        ?W(MonitorsStr, 112),
+        ?W(MonitorsStr, LinkValueW),
         ?NEW_LINE,
         ?W(MonitoredByInfo, 16),
-        ?W(MonitoredByStr, 112)
+        ?W(MonitoredByStr, LinkValueW)
     ]).
+
+process_info_widths(Base) ->
+    fill_last(observer_cli_lib:weighted_widths(Base, [0, 4, 0, 1, 0, 1]), wide_fill(5)).
 
 render_reduction_memory(Reduction, Memory, ReductionQ, MemoryQ) ->
     {NewRed, NewMem} =
@@ -420,14 +426,28 @@ render_reduction_memory(Reduction, Memory, ReductionQ, MemoryQ) ->
             false ->
                 {queue:in(Reduction, ReductionQ), queue:in(Memory, MemoryQ)}
         end,
+    Extra = observer_cli_lib:layout_extra_width(),
+    RedWidth = 120 + Extra + wide_fill(5),
+    MemWidth = 124 + Extra + wide_fill(5),
     View = [
-        io_lib:format("|Reductions: ~120.120s|~n", [get_chart_format(NewRed)]),
-        io_lib:format("|Memory: ~124.124s|~n", [get_chart_format(NewMem)])
+        io_lib:format("|Reductions: ~*.*s|~n", [RedWidth, RedWidth, get_chart_format(NewRed)]),
+        io_lib:format("|Memory: ~*.*s|~n", [MemWidth, MemWidth, get_chart_format(NewMem)])
     ],
     {NewRed, NewMem, View}.
 
+wide_fill(Amount) ->
+    case observer_cli_lib:layout_extra_width() of
+        0 -> 0;
+        _ -> Amount
+    end.
+
+fill_last([Last], Amount) ->
+    [Last + Amount];
+fill_last([Width | Rest], Amount) ->
+    [Width | fill_last(Rest, Amount)].
+
 render_last_line() ->
-    io_lib:format("|\e[7mq(quit) ~124.124s\e[0m|~n", [" "]).
+    observer_cli_lib:render_last_line("q(quit)").
 
 get_chart_format(Queue) ->
     List = queue:to_list(Queue),
@@ -446,7 +466,7 @@ render_menu(Type, Menu, Interval) ->
     Text = "Interval: " ++ integer_to_list(Interval) ++ "ms",
     Title = get_menu_title(Type, Menu),
     UpTime = observer_cli_lib:uptime(),
-    TitleWidth = ?COLUMN + 104 - erlang:length(UpTime),
+    TitleWidth = ?COLUMN + 104 - erlang:length(UpTime) + observer_cli_lib:layout_extra_width(),
     ?render([?W([Title | Text], TitleWidth) | UpTime]).
 
 get_menu_title(Type, Menu) ->
@@ -606,16 +626,10 @@ replace_first_line(Line, NewLine) ->
     end.
 
 state_footer(_Menu, Nav) ->
-    Text = state_footer_text(Nav),
-    render_footer_line(Text, ?COLUMN).
+    observer_cli_lib:render_last_line(state_footer_text(Nav)).
 
 state_footer_text(_Nav) ->
     "q(quit)    F/B(page forward/back)".
-
-render_footer_line(Text, Width) ->
-    InnerWidth = Width - 3,
-    Padding = lists:duplicate(InnerWidth - erlang:length(Text), $\s),
-    ["|", ?GRAY_BG, Text, Padding, " ", ?RESET, "|", "\n"].
 
 truncate_str(Pid, Term) ->
     State = #{

--- a/src/observer_cli_system.erl
+++ b/src/observer_cli_system.erl
@@ -112,17 +112,18 @@ get_dist_nodes_info() ->
 render_dist_node_info([]) ->
     [];
 render_dist_node_info(DistNodesInfo) ->
+    [NodeW, QueueW, PercentW, AddressW, InW, OutW, TypeW, StateW] = dist_node_widths(),
     Title = ?render([
         ?UNDERLINE,
         ?GRAY_BG,
-        ?W("Node", 30),
-        ?W("Dist Node Queue Size Bytes", 20),
-        ?W("Percent", 7),
-        ?W("Address", 19),
-        ?W("In", 11),
-        ?W("Out", 11),
-        ?W("Type", 7),
-        ?W("State", 10)
+        ?W("Node", NodeW),
+        ?W("Dist Node Queue Size Bytes", QueueW),
+        ?W("Percent", PercentW),
+        ?W("Address", AddressW),
+        ?W("In", InW),
+        ?W("Out", OutW),
+        ?W("Type", TypeW),
+        ?W("State", StateW)
     ]),
     Limit = erlang:system_info(dist_buf_busy_limit),
     LimitStr = integer_to_list(Limit),
@@ -145,19 +146,25 @@ render_dist_node_info(DistNodesInfo) ->
                         "unsupported"
                 end,
             ?render([
-                ?W(Node, 30),
-                ?W(QueueSizeLimitStr, 20),
-                ?W(Percent, 7),
-                ?W(Address, 19),
-                ?W(In, 11),
-                ?W(Out, 11),
-                ?W(Type, 7),
-                ?W(State, 10)
+                ?W(Node, NodeW),
+                ?W(QueueSizeLimitStr, QueueW),
+                ?W(Percent, PercentW),
+                ?W(Address, AddressW),
+                ?W(In, InW),
+                ?W(Out, OutW),
+                ?W(Type, TypeW),
+                ?W(State, StateW)
             ])
         end,
         lists:sort(DistNodesInfo)
     ),
     [Title | View].
+
+dist_node_widths() ->
+    observer_cli_lib:weighted_widths(
+        [30, 20, 7, 19, 11, 11, 7, 10],
+        [4, 1, 0, 4, 0, 0, 0, 0]
+    ).
 
 get_address(Info) ->
     #net_address{address = Address} = proplists:get_value(address, Info, #net_address{}),
@@ -219,22 +226,24 @@ render_cache_hit_rates(CacheHitInfo, Len) when Len =< 8 ->
     ],
     [Title | View];
 render_cache_hit_rates(CacheHitInfo, Len) ->
+    [HitCalls1W, HitCalls2W, HitCalls3W, HitCalls4W] = cache_hit_title_widths(),
     Title = ?render([
         ?UNDERLINE,
         ?GRAY_BG,
         "IN|",
-        ?W(" Hits/Calls", 20),
+        ?W(" Hits/Calls", HitCalls1W),
         ?W("HitRate", 6),
         "IN|",
-        ?W(" Hits/Calls", 20),
+        ?W(" Hits/Calls", HitCalls2W),
         ?W("HitRate", 6),
         "IN|",
-        ?W(" Hits/Calls", 20),
+        ?W(" Hits/Calls", HitCalls3W),
         ?W("HitRate", 6),
         "IN|",
-        ?W(" Hits/Calls", 19),
+        ?W(" Hits/Calls", HitCalls4W),
         ?W("HitRate", 6)
     ]),
+    [HitCallsRow1W, HitCallsRow2W, HitCallsRow3W, HitCallsRow4W] = cache_hit_row_widths(),
     Num = Len div 4,
     Rows = [
         begin
@@ -247,16 +256,16 @@ render_cache_hit_rates(CacheHitInfo, Len) ->
             {SeqStr4, Hit4, Call4, HitRateStr4} = get_cachehit_info(Seq4, CacheHitInfo),
             ?render([
                 SeqStr1,
-                ?W([Hit1, "/", Call1], 19),
+                ?W([Hit1, "/", Call1], HitCallsRow1W),
                 ?W(HitRateStr1, 6),
                 SeqStr2,
-                ?W([Hit2, "/", Call2], 19),
+                ?W([Hit2, "/", Call2], HitCallsRow2W),
                 ?W(HitRateStr2, 6),
                 SeqStr3,
-                ?W([Hit3, "/", Call3], 19),
+                ?W([Hit3, "/", Call3], HitCallsRow3W),
                 ?W(HitRateStr3, 6),
                 SeqStr4,
-                ?W([Hit4, "/", Call4], 18),
+                ?W([Hit4, "/", Call4], HitCallsRow4W),
                 ?W(HitRateStr4, 6)
             ])
         end
@@ -265,16 +274,18 @@ render_cache_hit_rates(CacheHitInfo, Len) ->
     [Title | Rows].
 
 render_block_size_info(AverageBlockCurs, AverageBlockMaxes, SbcsToMbcsCurs, SbcsToMbcsMaxs) ->
+    [AllocatorW, CurrentMbcsW, MaxMbcsW, CurrentSbcsW, MaxSbcsW, CurrentSbcsToMbcsW, MaxSbcsToMbcsW] =
+        block_size_widths(),
     Title = ?render([
         ?UNDERLINE,
         ?GRAY_BG,
-        ?W("Allocator Type", 16),
-        ?W("Current Mbcs", 16),
-        ?W("Max Mbcs", 16),
-        ?W("Current Sbcs", 16),
-        ?W("Max Sbcs", 16),
-        ?W("Current SbcsToMbcs", 19),
-        ?W("Max SbcsToMbcs", 19)
+        ?W("Allocator Type", AllocatorW),
+        ?W("Current Mbcs", CurrentMbcsW),
+        ?W("Max Mbcs", MaxMbcsW),
+        ?W("Current Sbcs", CurrentSbcsW),
+        ?W("Max Sbcs", MaxSbcsW),
+        ?W("Current SbcsToMbcs", CurrentSbcsToMbcsW),
+        ?W("Max SbcsToMbcs", MaxSbcsToMbcsW)
     ]),
     View = [
         begin
@@ -287,18 +298,30 @@ render_block_size_info(AverageBlockCurs, AverageBlockMaxes, SbcsToMbcsCurs, Sbcs
                     SbcsToMbcsMaxs
                 ),
             ?render([
-                ?W(Type, 16),
-                ?W(CMC, 16),
-                ?W(MMC, 16),
-                ?W(CSC, 16),
-                ?W(MSBC, 16),
-                ?W(CSTM, 19),
-                ?W(MSTM, 19)
+                ?W(Type, AllocatorW),
+                ?W(CMC, CurrentMbcsW),
+                ?W(MMC, MaxMbcsW),
+                ?W(CSC, CurrentSbcsW),
+                ?W(MSBC, MaxSbcsW),
+                ?W(CSTM, CurrentSbcsToMbcsW),
+                ?W(MSTM, MaxSbcsToMbcsW)
             ])
         end
      || AllocKey <- ?UTIL_ALLOCATORS
     ],
     [Title | View].
+
+cache_hit_title_widths() ->
+    observer_cli_lib:weighted_widths([20, 20, 20, 19], [1, 1, 1, 1]).
+
+cache_hit_row_widths() ->
+    observer_cli_lib:weighted_widths([19, 19, 19, 18], [1, 1, 1, 1]).
+
+block_size_widths() ->
+    observer_cli_lib:weighted_widths(
+        [16, 16, 16, 16, 16, 19, 19],
+        [0, 1, 1, 1, 1, 2, 2]
+    ).
 
 get_alloc(Key, Curs, Maxes, STMCurs, STMMaxes) ->
     CurRes = proplists:get_value(Key, Curs),
@@ -329,18 +352,41 @@ render_sys_info(Cmd) ->
     render_sys_info(System, CPU, Memory, Statistics).
 
 render_sys_info(System, CPU, Memory, Statistics) ->
+    [
+        SystemTitleW,
+        SystemStateTitleW,
+        CpuTitleW,
+        CpuStateTitleW,
+        MemoryTitleW,
+        MemoryStateTitleW,
+        StatisticsTitleW,
+        StatisticsStateTitleW
+    ] =
+        sys_info_title_widths(),
     Title = ?render([
         ?GRAY_BG,
         ?UNDERLINE,
-        ?W("System/Architecture", 22),
-        ?W("State", 8),
-        ?W("CPU's and Threads", 23),
-        ?W("State", 7),
-        ?W("Memory Usage", 11),
-        ?W("State", 22),
-        ?W("Statistics", 11),
-        ?W("State", 11)
+        ?W("System/Architecture", SystemTitleW),
+        ?W("State", SystemStateTitleW),
+        ?W("CPU's and Threads", CpuTitleW),
+        ?W("State", CpuStateTitleW),
+        ?W("Memory Usage", MemoryTitleW),
+        ?W("State", MemoryStateTitleW),
+        ?W("Statistics", StatisticsTitleW),
+        ?W("State", StatisticsStateTitleW)
     ]),
+    [
+        SystemW,
+        SystemStateW,
+        CpuW,
+        CpuStateW,
+        MemoryW,
+        MemoryValueW,
+        MemoryPercentW,
+        StatisticsW,
+        StatisticsStateW
+    ] =
+        sys_info_row_widths(),
     NewSystem = [
         begin
             {Key, Value}
@@ -360,25 +406,41 @@ render_sys_info(System, CPU, Memory, Statistics) ->
             {bytes, MemValInt} = MemVal,
             Percent = observer_cli_lib:to_percent(MemValInt / TotalMemInt),
             ?render([
-                ?W(SysKey, 22),
-                ?W(to_list(SysVal), 8),
-                ?W(CpuKey, 23),
-                ?W(to_list(CpuVal), 7),
-                ?W(MemKey, 11),
-                ?W(observer_cli_lib:to_byte(MemValInt), 13),
-                ?W(Percent, 6),
-                ?W(StatisticsKey, 11),
-                ?W(to_list(StatisticsVal), 11)
+                ?W(SysKey, SystemW),
+                ?W(to_list(SysVal), SystemStateW),
+                ?W(CpuKey, CpuW),
+                ?W(to_list(CpuVal), CpuStateW),
+                ?W(MemKey, MemoryW),
+                ?W(observer_cli_lib:to_byte(MemValInt), MemoryValueW),
+                ?W(Percent, MemoryPercentW),
+                ?W(StatisticsKey, StatisticsW),
+                ?W(to_list(StatisticsVal), StatisticsStateW)
             ])
         end
      || Pos <- lists:seq(1, 6)
     ],
+    [CompiledForW, CompiledValueW] = compiled_for_widths(),
     Compile = ?render([
         ?UNDERLINE,
-        ?W("compiled for", 22),
-        ?W(to_list(proplists:get_value("Compiled for", System)), 111)
+        ?W("compiled for", CompiledForW),
+        ?W(to_list(proplists:get_value("Compiled for", System)), CompiledValueW)
     ]),
     [Title | (Row ++ [Compile])].
+
+sys_info_title_widths() ->
+    observer_cli_lib:weighted_widths(
+        [22, 8, 23, 7, 11, 22, 11, 11],
+        [0, 1, 0, 1, 0, 1, 0, 1]
+    ).
+
+sys_info_row_widths() ->
+    observer_cli_lib:weighted_widths(
+        [22, 8, 23, 7, 11, 13, 6, 11, 11],
+        [0, 1, 0, 1, 0, 1, 0, 0, 1]
+    ).
+
+compiled_for_widths() ->
+    observer_cli_lib:weighted_widths([22, 111], [0, 1]).
 
 sys_info(Cmd) ->
     MemInfo =

--- a/test/observer_cli_application_test.erl
+++ b/test/observer_cli_application_test.erl
@@ -74,4 +74,39 @@ start_manager_branches_test() ->
 find_group_leader_test() ->
     ?assert(is_pid(observer_cli_application:find_group_leader(self()))).
 
+render_app_info_wide_layout_test() ->
+    Base = app_row_widths(80),
+    Wide = app_row_widths(180),
+    ?assertEqual([1, 3, 4, 6, 7], unchanged_columns(Base, Wide, [1, 3, 4, 6, 7])),
+    ?assertEqual([2, 5, 8], wider_columns(Base, Wide, [2, 5, 8])).
+
+app_row_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Row | _] = observer_cli_application:render_app_info(
+                20, 1, {proc_count, 1}
+            ),
+            {observer_cli_test_io:column_widths(Title), observer_cli_test_io:column_widths(Row)}
+        end
+    ).
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ].
+
 -endif.

--- a/test/observer_cli_core_test.erl
+++ b/test/observer_cli_core_test.erl
@@ -96,6 +96,53 @@ render_memory_process_line_error_logger_test() ->
         end
     end.
 
+render_home_summary_wide_layout_test() ->
+    observer_cli_test_io:with_geometry(
+        24,
+        160,
+        [],
+        fun() ->
+            {StableInfo, PortParallelism} = observer_cli:get_stable_system_info(),
+            SystemLines = observer_cli:render_system_line(
+                "printf 'header\n 1 2\n'", StableInfo
+            ),
+            MemLines = observer_cli:render_memory_process_line(
+                {1, 2, 3, 4}, PortParallelism, 1500
+            ),
+            [SystemTitle | _] = SystemLines,
+            [MemTitle | _] = MemLines,
+            ?assertEqual(
+                observer_cli_lib:layout_width(), hd(home_summary_line_lengths(SystemTitle))
+            ),
+            ?assertEqual([15, 26, 30, 25, 25, 31], home_summary_widths(SystemTitle)),
+            ?assertEqual([15, 26, 30, 25, 25, 31], home_summary_widths(MemTitle)),
+            ?assert(
+                lists:all(
+                    fun(Len) -> Len =< observer_cli_lib:layout_width() end,
+                    home_summary_line_lengths(SystemTitle)
+                )
+            ),
+            ?assert(
+                lists:all(
+                    fun(Len) -> Len =< observer_cli_lib:layout_width() end,
+                    home_summary_line_lengths(MemTitle)
+                )
+            ),
+            ?assert(
+                lists:all(
+                    fun(Len) -> Len =< observer_cli_lib:layout_width() end,
+                    rendered_line_lengths(SystemLines)
+                )
+            ),
+            ?assert(
+                lists:all(
+                    fun(Len) -> Len =< observer_cli_lib:layout_width() end,
+                    rendered_line_lengths(MemLines)
+                )
+            )
+        end
+    ).
+
 render_scheduler_usage_test() ->
     ?assertEqual({0, []}, observer_cli:render_scheduler_usage(undefined)),
     {2, _} = observer_cli:render_scheduler_usage([{1, 0.1}, {2, 0.2}, {3, 0.3}, {4, 0.4}]),
@@ -111,6 +158,35 @@ render_scheduler_usage_test() ->
     ),
     {11, _} = observer_cli:render_scheduler_usage(
         lists:map(fun(N) -> {N, 0.1} end, lists:seq(1, 110))
+    ).
+
+render_scheduler_usage_wide_layout_test() ->
+    observer_cli_test_io:with_geometry(
+        24,
+        160,
+        [],
+        fun() ->
+            Samples = [
+                [{1, 0.1}, {2, 0.2}, {3, 0.3}, {4, 0.4}],
+                lists:map(fun(N) -> {N, 0.1} end, lists:seq(1, 8)),
+                lists:map(fun(N) -> {N, 0.1} end, lists:seq(1, 101))
+            ],
+            ?assert(
+                lists:all(
+                    fun(SchedulerUsage) ->
+                        {_Rows, Lines} = observer_cli:render_scheduler_usage(SchedulerUsage),
+                        lists:all(
+                            fun(Line) ->
+                                observer_cli_lib:visible_length(Line) =:=
+                                    observer_cli_lib:layout_width()
+                            end,
+                            Lines
+                        )
+                    end,
+                    Samples
+                )
+            )
+        end
     ).
 
 render_top_n_view_test() ->
@@ -146,6 +222,21 @@ render_top_n_view_test() ->
     ?assertEqual(3, length(Rows5)),
     erlang:exit(Pid2, kill),
     {PidList1, Rows1, Rows2, Rows3, Rows4, Rows5}.
+
+render_top_n_view_wide_layout_test() ->
+    Pid = self(),
+    Call = [
+        {registered_name, undefined},
+        {current_function,
+            {very_long_current_module_for_layout, very_long_current_function_for_layout, 2}},
+        {initial_call,
+            {very_long_initial_module_for_layout, very_long_initial_function_for_layout, 1}}
+    ],
+    {_, [Title, Row]} = observer_cli:render_top_n_view(
+        memory, [{Pid, 1000, Call}], 1, [{1, 1}], 1, 160
+    ),
+    ?assertEqual(160, observer_cli_lib:visible_length(Title)),
+    ?assertEqual(160, observer_cli_lib:visible_length(Row)).
 
 get_top_n_info_translated_call_test() ->
     Pid = spawn(fun() -> receive
@@ -240,5 +331,34 @@ node_stats_test() ->
 
 check_auto_row_test() ->
     ?assert(is_boolean(observer_cli:check_auto_row())).
+
+home_summary_widths(IoData) ->
+    Header =
+        case non_empty_lines(IoData) of
+            [_First, Second | _] -> Second;
+            [Only] -> Only
+        end,
+    Parts = string:split(Header, "|", all),
+    Inner = lists:sublist(Parts, 2, length(Parts) - 2),
+    [length(P) || P <- Inner].
+
+non_empty_lines(IoData) ->
+    [Line || Line <- string:split(plain(IoData), "\n", all), Line =/= ""].
+
+home_summary_line_lengths(IoData) ->
+    [length(Line) || Line <- non_empty_lines(IoData)].
+
+rendered_line_lengths(IoDatas) ->
+    lists:flatmap(fun home_summary_line_lengths/1, IoDatas).
+
+plain(IoData) ->
+    binary_to_list(
+        re:replace(
+            unicode:characters_to_binary(IoData),
+            <<"\e\\[[0-9;]*[A-Za-z]">>,
+            <<>>,
+            [global, {return, binary}]
+        )
+    ).
 
 -endif.

--- a/test/observer_cli_ets_test.erl
+++ b/test/observer_cli_ets_test.erl
@@ -48,4 +48,43 @@ unread_test() ->
     {_, _, Info} = observer_cli_ets:unread(),
     ?assertEqual(unread, proplists:get_value(name, Info)).
 
+render_ets_info_wide_layout_test() ->
+    TabName = wide_layout_ets_table,
+    ets:new(TabName, [named_table, public, set]),
+    try
+        Base = ets_row_widths(80),
+        Wide = ets_row_widths(180),
+        ?assertEqual([4, 5, 6, 7], unchanged_columns(Base, Wide, [4, 5, 6, 7])),
+        ?assertEqual([1, 2, 3, 8], wider_columns(Base, Wide, [1, 2, 3, 8]))
+    after
+        ets:delete(TabName)
+    end.
+
+ets_row_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Row | _] = observer_cli_ets:render_ets_info(20, 1, size),
+            {observer_cli_test_io:column_widths(Title), observer_cli_test_io:column_widths(Row)}
+        end
+    ).
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ].
+
 -endif.

--- a/test/observer_cli_help_test.erl
+++ b/test/observer_cli_help_test.erl
@@ -39,6 +39,21 @@ render_help_test() ->
     Text = lists:flatten(observer_cli_help:render_help()),
     ?assert(string:find(Text, "Start Mode") =/= nomatch).
 
+render_help_grouping_test() ->
+    Text = lists:flatten(observer_cli_help:render_help()),
+    ?assert(string:find(Text, "Doc - Shortcuts and command examples") =/= nomatch),
+    StartSection = section_text(Text, "1. Start Mode", "2. Global Commands"),
+    GlobalSection = section_text(Text, "2. Global Commands", "3. HOME(H) Commands"),
+    HomeSection = section_text(Text, "3. HOME(H) Commands", "4. Process Select Examples"),
+    ProcessSection = section_text(Text, "4. Process Select Examples", "5. Reference"),
+    ReferenceSection = after_text(Text, "5. Reference"),
+    ?assert(string:find(StartSection, "observer_cli:start().") =/= nomatch),
+    ?assert(string:find(GlobalSection, "pause/unpause") =/= nomatch),
+    ?assertEqual(nomatch, string:find(HomeSection, "pause/unpause")),
+    ?assert(string:find(HomeSection, "schedule usage") =/= nomatch),
+    ?assert(string:find(ProcessSection, "<0.43.0>") =/= nomatch),
+    ?assert(string:find(ReferenceSection, "github.com/ferd/recon") =/= nomatch).
+
 render_doc_test() ->
     ok = observer_cli_help:render_doc("Interval: 1000ms").
 
@@ -52,5 +67,13 @@ render_worker_redraw_test() ->
     after 1000 ->
         ok
     end.
+
+after_text(Text, Pattern) ->
+    [_, After] = string:split(Text, Pattern, leading),
+    After.
+
+section_text(Text, StartPattern, EndPattern) ->
+    [Section, _AfterEnd] = string:split(after_text(Text, StartPattern), EndPattern, leading),
+    Section.
 
 -endif.

--- a/test/observer_cli_inet_test.erl
+++ b/test/observer_cli_inet_test.erl
@@ -151,6 +151,30 @@ render_io_rows_test() ->
     {Row, _} = observer_cli_inet:render_io_rows({0, 0}),
     ?assert(string:find(lists:flatten(Row), "Byte Input") =/= nomatch).
 
+render_io_rows_wide_layout_test() ->
+    Base = io_row_widths(80),
+    Wide = io_row_widths(180),
+    ?assertEqual([1, 3, 5, 7], unchanged_columns(Base, Wide, [1, 3, 5, 7])),
+    ?assertEqual([2, 4, 6, 8], wider_columns(Base, Wide, [2, 4, 6, 8])).
+
+render_inet_rows_wide_layout_test() ->
+    {ok, Listen} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(Listen),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listen),
+    try
+        Base = inet_row_widths(Server, 80),
+        Wide = inet_row_widths(Server, 180),
+        ?assertEqual([1, 8], unchanged_columns(Base, Wide, [1, 8])),
+        ?assertEqual(
+            [2, 3, 4, 5, 6, 7, 9, 10], wider_columns(Base, Wide, [2, 3, 4, 5, 6, 7, 9, 10])
+        )
+    after
+        gen_tcp:close(Client),
+        gen_tcp:close(Server),
+        gen_tcp:close(Listen)
+    end.
+
 start_new_interval_test() ->
     observer_cli_test_io:with_input(
         ["1600\n", "q\n"],
@@ -203,5 +227,48 @@ start_port_view_auto_jump_test() ->
     after
         gen_tcp:close(Listen)
     end.
+
+io_row_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            {Row, _} = observer_cli_inet:render_io_rows({0, 0}),
+            observer_cli_test_io:column_widths(Row)
+        end
+    ).
+
+inet_row_widths(Server, Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Opts = #inet{type = recv_cnt, cur_page = 1, pages = [{1, 1}]},
+            {_, [Title, Row]} = observer_cli_inet:render_inet_rows([{Server, 1, []}], 1, Opts),
+            {observer_cli_test_io:column_widths(Title), observer_cli_test_io:column_widths(Row)}
+        end
+    ).
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ];
+unchanged_columns(Base, Wide, Columns) ->
+    [Pos || Pos <- Columns, lists:nth(Pos, Base) =:= lists:nth(Pos, Wide)].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ];
+wider_columns(Base, Wide, Columns) ->
+    [Pos || Pos <- Columns, lists:nth(Pos, Wide) > lists:nth(Pos, Base)].
 
 -endif.

--- a/test/observer_cli_lib_test.erl
+++ b/test/observer_cli_lib_test.erl
@@ -20,6 +20,33 @@ render_last_line_test() ->
     Line = observer_cli_lib:render_last_line("q(quit)"),
     ?assert(string:find(lists:flatten(Line), "q(quit)") =/= nomatch).
 
+render_keeps_unicode_text_test() ->
+    Line = observer_cli_lib:render([?W("中文", 10)]),
+    ?assert(string:find(Line, "中文") =/= nomatch).
+
+layout_width_keeps_base_width_test() ->
+    observer_cli_test_io:with_geometry(
+        24,
+        80,
+        [],
+        fun() ->
+            ?assertEqual(?COLUMN + 5, observer_cli_lib:layout_width())
+        end
+    ).
+
+layout_width_uses_wide_terminal_test() ->
+    observer_cli_test_io:with_geometry(
+        24,
+        160,
+        [],
+        fun() ->
+            ?assertEqual(159, observer_cli_lib:layout_width()),
+            ?assertEqual(
+                159, observer_cli_lib:visible_length(observer_cli_lib:render_last_line("q"))
+            )
+        end
+    ).
+
 get_terminal_rows_test() ->
     application:set_env(observer_cli, default_row_size, 20),
     ?assertEqual(20, observer_cli_lib:get_terminal_rows(false)),

--- a/test/observer_cli_mnesia_test.erl
+++ b/test/observer_cli_mnesia_test.erl
@@ -61,6 +61,57 @@ get_table_list_running_test() ->
         cleanup_mnesia(Dir)
     end.
 
+render_mnesia_wide_layout_test() ->
+    Base = mnesia_row_widths(80),
+    Wide = mnesia_row_widths(180),
+    ?assertEqual([2, 3, 4, 7], unchanged_columns(Base, Wide, [2, 3, 4, 7])),
+    ?assertEqual([1, 5, 6, 8], wider_columns(Base, Wide, [1, 5, 6, 8])).
+
+mnesia_row_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Row] = observer_cli_mnesia:render_mnesia(
+                [mnesia_fixture()], memory, 10, 1
+            ),
+            {observer_cli_test_io:column_widths(Title), observer_cli_test_io:column_widths(Row)}
+        end
+    ).
+
+mnesia_fixture() ->
+    {
+        0,
+        0,
+        [
+            {name, very_long_mnesia_table_name_for_layout},
+            {memory, 1024},
+            {size, 1},
+            {type, set},
+            {storage, ram_copies},
+            {owner, self()},
+            {index, []},
+            {reg_name, very_long_registered_name_for_layout}
+        ]
+    }.
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ].
+
 setup_mnesia(Dir) ->
     mnesia:stop(),
     catch mnesia:delete_schema([node()]),

--- a/test/observer_cli_port_test.erl
+++ b/test/observer_cli_port_test.erl
@@ -112,6 +112,16 @@ render_port_info_queue_size_test() ->
     ?assert(string:find(lists:flatten(Title), "Attr") =/= nomatch),
     ?assert(string:find(lists:flatten(Rows), "queue_size") =/= nomatch).
 
+render_port_info_wide_layout_test() ->
+    Base = port_info_widths(80),
+    Wide = port_info_widths(180),
+    ?assertEqual([1, 3, 5], unchanged_columns(Base, Wide, [1, 3, 5])),
+    ?assertEqual([2, 4, 6], wider_columns(Base, Wide, [2, 4, 6])).
+
+render_port_info_wide_alignment_test() ->
+    {Title, Rows} = port_info_columns(205),
+    ?assert(lists:all(fun(Row) -> Row =:= Title end, Rows)).
+
 render_link_monitor_test() ->
     Line = observer_cli_port:render_link_monitor([self()], [{process, self()}]),
     ?assert(string:find(lists:flatten(Line), "Links(") =/= nomatch).
@@ -119,6 +129,23 @@ render_link_monitor_test() ->
 render_link_monitor_named_test() ->
     Line = observer_cli_port:render_link_monitor([self()], [{reg_name, node()}]),
     ?assert(string:find(lists:flatten(Line), "/") =/= nomatch).
+
+render_link_monitor_wide_layout_test() ->
+    Base = port_link_widths(80),
+    Wide = port_link_widths(180),
+    ?assert(
+        lists:all(
+            fun({BaseLine, WideLine}) ->
+                lists:nth(1, BaseLine) =:= lists:nth(1, WideLine) andalso
+                    lists:nth(2, WideLine) > lists:nth(2, BaseLine)
+            end,
+            lists:zip(Base, Wide)
+        )
+    ).
+
+render_link_monitor_wide_alignment_test() ->
+    [First | Rest] = port_link_widths(205),
+    ?assert(lists:all(fun(Row) -> Row =:= First end, Rest)).
 
 render_type_line_test() ->
     Stats = [
@@ -169,8 +196,209 @@ render_type_line_missing_fields_test() ->
     ]),
     ?assert(string:find(lists:flatten(Line), "sockname") =/= nomatch).
 
+render_type_line_wide_layout_test() ->
+    Base = type_line_widths(80),
+    Wide = type_line_widths(180),
+    ?assert(lists:nth(1, Wide) > lists:nth(1, Base)),
+    ?assertEqual(lists:nth(2, Base), lists:nth(2, Wide)),
+    ?assert(lists:nth(3, Wide) > lists:nth(3, Base)).
+
+render_stats_wide_layout_test() ->
+    Base = stats_widths(80),
+    Wide = stats_widths(180),
+    ?assertEqual([1, 3, 5, 7, 9], same_columns(Base, Wide, [1, 3, 5, 7, 9])),
+    ?assertEqual([2, 4, 6, 8], wider_columns(Base, Wide, [2, 4, 6, 8])).
+
+render_stats_wide_alignment_test() ->
+    [First | Rest] = stats_columns(205),
+    ?assert(lists:all(fun(Row) -> Row =:= First end, Rest)).
+
+render_opts_wide_layout_test() ->
+    Base = opts_widths(80),
+    Wide = opts_widths(180),
+    ?assertEqual([1, 3, 5, 7, 9], unchanged_columns(Base, Wide, [1, 3, 5, 7, 9])),
+    ?assertEqual([2, 4, 6, 8], wider_columns(Base, Wide, [2, 4, 6, 8])).
+
+render_opts_wide_alignment_test() ->
+    {Title, Rows} = opts_columns(205),
+    ?assert(lists:all(fun(Row) -> Row =:= Title end, Rows)).
+
+render_info_page_wide_border_alignment_test() ->
+    {LayoutWidth, LineWidths} = port_info_page_line_widths(205),
+    ?assert(lists:all(fun(Width) -> Width =:= LayoutWidth end, LineWidths)).
+
 render_menu_test() ->
     Line = observer_cli_port:render_menu(info, 1000),
     ?assert(string:find(lists:flatten(Line), "Interval: 1000ms") =/= nomatch).
+
+port_info_widths(Columns) ->
+    {Title, [FirstRow | _]} = port_info_columns(Columns),
+    {Title, FirstRow}.
+
+port_info_columns(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Rows] = observer_cli_port:render_port_info(port_view()),
+            {
+                observer_cli_test_io:column_widths(Title),
+                observer_cli_test_io:line_column_widths(Rows)
+            }
+        end
+    ).
+
+port_link_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Line = observer_cli_port:render_link_monitor([self()], [{process, self()}]),
+            observer_cli_test_io:line_column_widths(Line)
+        end
+    ).
+
+type_line_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Line = observer_cli_port:render_type_line([
+                {peername, {{127, 0, 0, 1}, 4000}},
+                {sockname, {{0, 0, 0, 0}, 0}}
+            ]),
+            observer_cli_test_io:column_widths(Line)
+        end
+    ).
+
+stats_widths(Columns) ->
+    [FirstRow | _] = stats_columns(Columns),
+    FirstRow.
+
+stats_columns(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Line = observer_cli_port:render_stats(stats_fixture()),
+            observer_cli_test_io:line_column_widths(Line)
+        end
+    ).
+
+opts_widths(Columns) ->
+    {Title, [FirstRow | _]} = opts_columns(Columns),
+    {Title, FirstRow}.
+
+opts_columns(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Rows] = observer_cli_port:render_opts(opts_fixture()),
+            {
+                observer_cli_test_io:column_widths(Title),
+                observer_cli_test_io:line_column_widths(Rows)
+            }
+        end
+    ).
+
+port_info_page_line_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            IoData = [
+                observer_cli_port:render_menu(info, 1500),
+                observer_cli_port:render_port_info(port_view()),
+                observer_cli_port:render_link_monitor([self()], [{process, self()}]),
+                observer_cli_port:render_type_line([
+                    {peername, {{127, 0, 0, 1}, 4369}},
+                    {sockname, {{127, 0, 0, 1}, 58521}},
+                    {statistics, stats_fixture()},
+                    {options, opts_fixture()}
+                ]),
+                observer_cli_port:render_last_line()
+            ],
+            {observer_cli_lib:layout_width(), observer_cli_test_io:line_widths(IoData)}
+        end
+    ).
+
+port_view() ->
+    #{
+        port => self(),
+        id => "id",
+        name => "very_long_port_name_for_layout",
+        os_pid => 123,
+        input => 10,
+        output => 20,
+        memory => 30,
+        queue_size => 0,
+        connected => connected
+    }.
+
+stats_fixture() ->
+    [
+        {recv_oct, 1},
+        {recv_cnt, 2},
+        {recv_max, 3},
+        {recv_avg, 4},
+        {recv_dvi, 5},
+        {send_oct, 6},
+        {send_cnt, 7},
+        {send_max, 8},
+        {send_avg, 9},
+        {send_pend, 10}
+    ].
+
+opts_fixture() ->
+    [
+        {active, false},
+        {broadcast, false},
+        {buffer, 0},
+        {delay_send, false},
+        {dontroute, false},
+        {exit_on_close, true},
+        {header, 0},
+        {high_watermark, 10},
+        {keepalive, false},
+        {linger, {false, 0}},
+        {low_watermark, 0},
+        {mode, binary},
+        {nodelay, false},
+        {packet, 0},
+        {packet_size, 0},
+        {priority, 0},
+        {recbuf, 0},
+        {reuseaddr, false},
+        {send_timeout, 0},
+        {sndbuf, 0}
+    ].
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ];
+wider_columns(Base, Wide, Columns) ->
+    [Pos || Pos <- Columns, lists:nth(Pos, Wide) > lists:nth(Pos, Base)].
+
+same_columns(Base, Wide, Columns) ->
+    [Pos || Pos <- Columns, lists:nth(Pos, Base) =:= lists:nth(Pos, Wide)].
 
 -endif.

--- a/test/observer_cli_process_test.erl
+++ b/test/observer_cli_process_test.erl
@@ -187,6 +187,16 @@ render_process_info_registered_test() ->
     ?assert(string:find(lists:flatten(Title), "Meta") =/= nomatch),
     ?assert(string:find(lists:flatten(Rows), "test_reg") =/= nomatch).
 
+render_process_info_wide_layout_test() ->
+    Base = process_info_widths(80),
+    Wide = process_info_widths(180),
+    ?assertEqual([1, 3, 5], unchanged_columns(Base, Wide, [1, 3, 5])),
+    ?assertEqual([2, 4, 6], wider_columns(Base, Wide, [2, 4, 6])).
+
+render_process_info_wide_alignment_test() ->
+    {Title, Rows} = process_info_columns(205),
+    ?assert(lists:all(fun(Row) -> Row =:= Title end, Rows)).
+
 render_link_monitor_test() ->
     Line = observer_cli_process:render_link_monitor([self()], [{process, self()}], [self()]),
     ?assert(string:find(lists:flatten(Line), "Links(") =/= nomatch).
@@ -206,6 +216,23 @@ render_link_monitor_variants_test() ->
         port_close(Port)
     end.
 
+render_link_monitor_wide_layout_test() ->
+    Base = process_link_widths(80),
+    Wide = process_link_widths(180),
+    ?assert(
+        lists:all(
+            fun({BaseLine, WideLine}) ->
+                lists:nth(1, BaseLine) =:= lists:nth(1, WideLine) andalso
+                    lists:nth(2, WideLine) > lists:nth(2, BaseLine)
+            end,
+            lists:zip(Base, Wide)
+        )
+    ).
+
+render_link_monitor_wide_alignment_test() ->
+    [First | Rest] = process_link_widths(205),
+    ?assert(lists:all(fun(Row) -> Row =:= First end, Rest)).
+
 render_reduction_memory_test() ->
     Q = queue:new(),
     {_RedQ, _MemQ, Lines} = observer_cli_process:render_reduction_memory(10, 20, Q, Q),
@@ -215,6 +242,28 @@ render_reduction_memory_queue_trim_test() ->
     Q = lists:foldl(fun(_, Acc) -> queue:in(1, Acc) end, queue:new(), lists:seq(1, 20)),
     {_RedQ, _MemQ, Lines} = observer_cli_process:render_reduction_memory(10, 20, Q, Q),
     ?assert(string:find(lists:flatten(Lines), "Reductions") =/= nomatch).
+
+render_reduction_memory_wide_layout_test() ->
+    Base = reduction_memory_widths(80),
+    Wide = reduction_memory_widths(220),
+    ?assert(lists:nth(1, Wide) > lists:nth(1, Base)),
+    ?assert(lists:nth(2, Wide) > lists:nth(2, Base)),
+    observer_cli_test_io:with_geometry(
+        24,
+        220,
+        [],
+        fun() ->
+            Q = queue:from_list(['NaN', 'NaN', 'NaN']),
+            {_RedQ, _MemQ, Lines} = observer_cli_process:render_reduction_memory(
+                'NaN', 'NaN', Q, Q
+            ),
+            ?assert(string:find(lists:flatten(Lines), "NaN") =/= nomatch)
+        end
+    ).
+
+render_info_page_wide_border_alignment_test() ->
+    {LayoutWidth, LineWidths} = process_info_page_line_widths(205),
+    ?assert(lists:all(fun(Width) -> Width =:= LayoutWidth end, LineWidths)).
 
 render_menu_test() ->
     Line = observer_cli_process:render_menu(info, home, 1500),
@@ -245,7 +294,7 @@ state_title_test() ->
 state_footer_text_test() ->
     Text = observer_cli_process:state_footer_text(#{}),
     ?assertEqual("q(quit)    F/B(page forward/back)", Text),
-    Line = observer_cli_process:render_footer_line(Text, 140),
+    Line = observer_cli_process:state_footer("menu", #{}),
     ?assert(string:find(lists:flatten(Line), "q(quit)") =/= nomatch).
 
 state_footer_test() ->
@@ -409,5 +458,107 @@ deep_stack_level3() ->
     receive
     after infinity -> ok
     end.
+
+process_info_widths(Columns) ->
+    {Title, [FirstRow | _]} = process_info_columns(Columns),
+    {Title, FirstRow}.
+
+process_info_columns(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Rows] = observer_cli_process:render_process_info(process_view()),
+            {
+                observer_cli_test_io:column_widths(Title),
+                observer_cli_test_io:line_column_widths(Rows)
+            }
+        end
+    ).
+
+process_link_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Line = observer_cli_process:render_link_monitor(
+                [self()], [{process, self()}], [self()]
+            ),
+            observer_cli_test_io:line_column_widths(Line)
+        end
+    ).
+
+reduction_memory_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Q = queue:from_list(['NaN', 'NaN', 'NaN']),
+            {_RedQ, _MemQ, Lines} = observer_cli_process:render_reduction_memory(
+                'NaN', 'NaN', Q, Q
+            ),
+            observer_cli_test_io:line_widths(Lines)
+        end
+    ).
+
+process_info_page_line_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            Q = queue:from_list([nan, nan, nan]),
+            {_RedQ, _MemQ, RedMem} = observer_cli_process:render_reduction_memory(
+                10, 20, Q, Q
+            ),
+            IoData = [
+                observer_cli_process:render_menu(info, home, 1500),
+                observer_cli_process:render_process_info(process_view()),
+                observer_cli_process:render_link_monitor([self()], [{process, self()}], [self()]),
+                RedMem,
+                observer_cli_process:render_last_line()
+            ],
+            {observer_cli_lib:layout_width(), observer_cli_test_io:line_widths(IoData)}
+        end
+    ).
+
+process_view() ->
+    GC = [
+        {min_bin_vheap_size, 1},
+        {min_heap_size, 2},
+        {fullsweep_after, 3},
+        {minor_gcs, 4}
+    ],
+    #{
+        pid => self(),
+        registered_name => test_reg,
+        group_leader => self(),
+        status => running,
+        trap_exit => true,
+        initial_call => {very_long_module_for_layout, very_long_function_for_layout, 1},
+        message_queue_len => 5,
+        heap_size => 10,
+        total_heap_size => 20,
+        garbage_collection => GC
+    }.
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ].
 
 -endif.

--- a/test/observer_cli_system_test.erl
+++ b/test/observer_cli_system_test.erl
@@ -122,6 +122,18 @@ render_sys_info_test() ->
     Line = observer_cli_system:render_sys_info(System, CPU, Memory, Statistics),
     ?assert(string:find(lists:flatten(Line), "System/Architecture") =/= nomatch).
 
+render_sys_info_wide_layout_test() ->
+    Base = sys_info_widths(80),
+    Wide = sys_info_widths(180),
+    {BaseTitle, BaseRow, BaseCompile} = Base,
+    {WideTitle, WideRow, WideCompile} = Wide,
+    ?assertEqual([1, 3, 5, 7], same_columns(BaseTitle, WideTitle, [1, 3, 5, 7])),
+    ?assertEqual([2, 4, 6, 8], wider_columns(BaseTitle, WideTitle, [2, 4, 6, 8])),
+    ?assertEqual([1, 3, 5, 7, 8], same_columns(BaseRow, WideRow, [1, 3, 5, 7, 8])),
+    ?assertEqual([2, 4, 6, 9], wider_columns(BaseRow, WideRow, [2, 4, 6, 9])),
+    ?assertEqual(lists:nth(1, BaseCompile), lists:nth(1, WideCompile)),
+    ?assert(lists:nth(2, WideCompile) > lists:nth(2, BaseCompile)).
+
 render_sys_info_empty_ps_test() ->
     Line = observer_cli_system:render_sys_info("printf 'header\\n'"),
     ?assert(string:find(lists:flatten(Line), "System/Architecture") =/= nomatch).
@@ -143,6 +155,12 @@ render_cache_hit_rates_test() ->
         ),
     Large = observer_cli_system:render_cache_hit_rates(LargeList, 12),
     ?assert(string:find(lists:flatten(Large), "IN|") =/= nomatch).
+
+render_cache_hit_rates_wide_layout_test() ->
+    Base = cache_hit_widths(80),
+    Wide = cache_hit_widths(180),
+    ?assertEqual([1, 3, 4, 6, 7, 9, 10], same_columns(Base, Wide, [1, 3, 4, 6, 7, 9, 10])),
+    ?assertEqual([2, 5, 8, 11], wider_columns(Base, Wide, [2, 5, 8, 11])).
 
 render_block_size_info_test() ->
     Allocators = [
@@ -169,6 +187,12 @@ render_block_size_info_test() ->
          || Item <- observer_cli_system:get_alloc(binary_alloc, Curs, Maxes, STMCurs, STMMaxs)
         ]
     ).
+
+render_block_size_info_wide_layout_test() ->
+    Base = block_size_widths(80),
+    Wide = block_size_widths(180),
+    ?assertEqual([1], same_columns(Base, Wide, [1])),
+    ?assertEqual([2, 3, 4, 5, 6, 7], wider_columns(Base, Wide, [2, 3, 4, 5, 6, 7])).
 
 get_address_invalid_test() ->
     Info = [{address, #net_address{address = {foo, 1234}}}],
@@ -205,6 +229,17 @@ render_dist_node_info_fake_test() ->
         false -> ok
     end.
 
+render_dist_node_info_wide_layout_test() ->
+    Created = ensure_sys_dist(),
+    try
+        Base = dist_node_widths(80),
+        Wide = dist_node_widths(180),
+        ?assertEqual([3, 5, 6, 7, 8], unchanged_columns(Base, Wide, [3, 5, 6, 7, 8])),
+        ?assertEqual([1, 2, 4], wider_columns(Base, Wide, [1, 2, 4]))
+    after
+        maybe_delete_sys_dist(Created)
+    end.
+
 render_worker_redraw_test() ->
     Cmd = "printf 'header\\n 1 2 3 4\\n'",
     Pid = spawn(fun() -> observer_cli_system:render_worker(Cmd, 1, ?INIT_TIME_REF) end),
@@ -217,5 +252,177 @@ render_worker_redraw_test() ->
     after 1000 ->
         ok
     end.
+
+sys_info_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Row | Rest] = observer_cli_system:render_sys_info(
+                system_fixture(), cpu_fixture(), memory_fixture(), statistics_fixture()
+            ),
+            Compile = lists:last(Rest),
+            {
+                observer_cli_test_io:column_widths(Title),
+                observer_cli_test_io:column_widths(Row),
+                observer_cli_test_io:column_widths(Compile)
+            }
+        end
+    ).
+
+dist_node_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title, Row] = observer_cli_system:render_dist_node_info(dist_node_fixture()),
+            {observer_cli_test_io:column_widths(Title), observer_cli_test_io:column_widths(Row)}
+        end
+    ).
+
+cache_hit_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title | _] = observer_cli_system:render_cache_hit_rates(cache_hit_fixture(), 12),
+            observer_cli_test_io:column_widths(Title)
+        end
+    ).
+
+block_size_widths(Columns) ->
+    observer_cli_test_io:with_geometry(
+        24,
+        Columns,
+        [],
+        fun() ->
+            [Title | _] = observer_cli_system:render_block_size_info(
+                allocator_curs(), allocator_maxes(), allocator_sbcs_curs(), allocator_sbcs_maxes()
+            ),
+            observer_cli_test_io:column_widths(Title)
+        end
+    ).
+
+cache_hit_fixture() ->
+    [
+        {{instance, Seq}, [{hit_rate, 0.1}, {hits, Seq}, {calls, Seq + 1}]}
+     || Seq <- lists:seq(1, 12)
+    ].
+
+allocator_curs() ->
+    [{A, [{mbcs, 1}, {sbcs, 2}]} || A <- allocators()].
+
+allocator_maxes() ->
+    [{A, [{mbcs, 3}, {sbcs, 4}]} || A <- allocators()].
+
+allocator_sbcs_curs() ->
+    [{A, "1"} || A <- allocators()].
+
+allocator_sbcs_maxes() ->
+    [{A, "2"} || A <- allocators()].
+
+allocators() ->
+    [
+        binary_alloc,
+        driver_alloc,
+        eheap_alloc,
+        ets_alloc,
+        fix_alloc,
+        ll_alloc,
+        sl_alloc,
+        std_alloc,
+        temp_alloc
+    ].
+
+system_fixture() ->
+    [
+        {"System Version", "A"},
+        {"Erts Version", "B"},
+        {"Compiled for", "C"},
+        {"Emulator Wordsize", 8},
+        {"Process Wordsize", 8},
+        {"Smp Support", true},
+        {"Thread Support", true},
+        {"Async thread pool size", 2}
+    ].
+
+cpu_fixture() ->
+    [
+        {"Logical CPU's", 1},
+        {"Online Logical CPU's", 1},
+        {"Available Logical CPU's", 1},
+        {"Schedulers", 1},
+        {"Online schedulers", 1},
+        {"Available schedulers", 1}
+    ].
+
+memory_fixture() ->
+    [
+        {"Total", {bytes, 100}},
+        {"Processes", {bytes, 10}},
+        {"Atoms", {bytes, 5}},
+        {"Binaries", {bytes, 2}},
+        {"Code", {bytes, 3}},
+        {"Ets", {bytes, 4}}
+    ].
+
+statistics_fixture() ->
+    [
+        {"ps -o pcpu", "1%"},
+        {"ps -o pmem", "2%"},
+        {"ps -o rss", {bytes, 3}},
+        {"ps -o vsz", {bytes, 4}},
+        {"Total IOIn", {bytes, 5}},
+        {"Total IOOut", {bytes, 6}}
+    ].
+
+dist_node_fixture() ->
+    [
+        {'very_long_fake_node_for_layout@127.0.0.1', [
+            {state, connected},
+            {type, normal},
+            {address, #net_address{address = {{127, 0, 0, 1}, 1234}}},
+            {in, 1},
+            {out, 2}
+        ]}
+    ].
+
+ensure_sys_dist() ->
+    case ets:info(sys_dist, owner) of
+        undefined ->
+            ets:new(sys_dist, [named_table, public, set]),
+            true;
+        _ ->
+            false
+    end.
+
+maybe_delete_sys_dist(true) ->
+    ets:delete(sys_dist);
+maybe_delete_sys_dist(false) ->
+    ok.
+
+unchanged_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, BaseTitle) =:= lists:nth(Pos, WideTitle),
+        lists:nth(Pos, BaseRow) =:= lists:nth(Pos, WideRow)
+    ].
+
+wider_columns({BaseTitle, BaseRow}, {WideTitle, WideRow}, Columns) ->
+    [
+        Pos
+     || Pos <- Columns,
+        lists:nth(Pos, WideTitle) > lists:nth(Pos, BaseTitle),
+        lists:nth(Pos, WideRow) > lists:nth(Pos, BaseRow)
+    ];
+wider_columns(Base, Wide, Columns) ->
+    [Pos || Pos <- Columns, lists:nth(Pos, Wide) > lists:nth(Pos, Base)].
+
+same_columns(Base, Wide, Columns) ->
+    [Pos || Pos <- Columns, lists:nth(Pos, Base) =:= lists:nth(Pos, Wide)].
 
 -endif.

--- a/test/observer_cli_test_io.erl
+++ b/test/observer_cli_test_io.erl
@@ -1,48 +1,121 @@
 -module(observer_cli_test_io).
 
--export([with_input/2]).
+-export([column_widths/1, line_column_widths/1, line_widths/1, plain/1]).
+-export([with_geometry/4, with_input/2]).
 
 with_input(Inputs, Fun) when is_list(Inputs), is_function(Fun, 0) ->
-    Pid = spawn(fun() -> io_server(Inputs) end),
+    with_geometry(24, 80, Inputs, Fun).
+
+with_geometry(Rows, Columns, Inputs, Fun) when is_list(Inputs), is_function(Fun, 0) ->
+    Owner = self(),
+    Pid = spawn(fun() -> io_server(Rows, Columns, Inputs, Owner, #{}) end),
     Old = group_leader(),
     group_leader(Pid, self()),
     try
         Fun()
     after
-        group_leader(Old, self())
+        group_leader(Old, self()),
+        Pid ! stop_when_idle
     end.
 
-io_server(Inputs) ->
+io_server(Rows, Columns, Inputs, Owner, Clients) ->
     receive
         stop ->
             ok;
+        stop_when_idle ->
+            drain_io_server(Rows, Columns, Inputs, Owner, Clients);
+        {'DOWN', Ref, process, Pid, _} ->
+            io_server(Rows, Columns, Inputs, Owner, drop_client(Pid, Ref, Clients));
         {io_request, From, ReplyAs, Request} ->
-            {Reply, NextInputs} = handle_request(Request, Inputs),
+            NextClients = track_client(From, Owner, Clients),
+            {Reply, NextInputs} = handle_request(Request, Rows, Columns, Inputs),
             From ! {io_reply, ReplyAs, Reply},
-            io_server(NextInputs)
+            io_server(Rows, Columns, NextInputs, Owner, NextClients)
     end.
 
-handle_request({get_line, _Enc, _Prompt}, Inputs) ->
+drain_io_server(Rows, Columns, Inputs, Owner, Clients) ->
+    receive
+        stop ->
+            ok;
+        {'DOWN', Ref, process, Pid, _} ->
+            drain_io_server(Rows, Columns, Inputs, Owner, drop_client(Pid, Ref, Clients));
+        {io_request, From, ReplyAs, Request} ->
+            NextClients = track_client(From, Owner, Clients),
+            {Reply, NextInputs} = handle_request(Request, Rows, Columns, Inputs),
+            From ! {io_reply, ReplyAs, Reply},
+            drain_io_server(Rows, Columns, NextInputs, Owner, NextClients)
+    after 100 ->
+        case maps:size(Clients) of
+            0 -> ok;
+            _ -> drain_io_server(Rows, Columns, Inputs, Owner, Clients)
+        end
+    end.
+
+track_client(Owner, Owner, Clients) ->
+    Clients;
+track_client(From, _Owner, Clients) ->
+    case maps:is_key(From, Clients) of
+        true -> Clients;
+        false -> maps:put(From, erlang:monitor(process, From), Clients)
+    end.
+
+drop_client(Pid, Ref, Clients) ->
+    case maps:get(Pid, Clients, undefined) of
+        Ref -> maps:remove(Pid, Clients);
+        _ -> Clients
+    end.
+
+handle_request({get_line, _Enc, _Prompt}, _Rows, _Columns, Inputs) ->
     case Inputs of
         [Line | Rest] -> {Line, Rest};
         [] -> {eof, []}
     end;
-handle_request({get_chars, _Enc, _Prompt, N}, Inputs) ->
+handle_request({get_chars, _Enc, _Prompt, N}, _Rows, _Columns, Inputs) ->
     case Inputs of
         [Line | Rest] -> {lists:sublist(Line, N), Rest};
         [] -> {eof, []}
     end;
-handle_request({put_chars, _Enc, _Chars}, Inputs) ->
+handle_request({put_chars, _Enc, _Chars}, _Rows, _Columns, Inputs) ->
     {ok, Inputs};
-handle_request({put_chars, _Chars}, Inputs) ->
+handle_request({put_chars, _Chars}, _Rows, _Columns, Inputs) ->
     {ok, Inputs};
-handle_request({setopts, _Opts}, Inputs) ->
+handle_request({setopts, _Opts}, _Rows, _Columns, Inputs) ->
     {ok, Inputs};
-handle_request({getopts, _Opts}, Inputs) ->
-    {{ok, [{rows, 24}, {columns, 80}]}, Inputs};
-handle_request({get_geometry, rows}, Inputs) ->
-    {24, Inputs};
-handle_request({get_geometry, columns}, Inputs) ->
-    {80, Inputs};
-handle_request(_Request, Inputs) ->
+handle_request({getopts, _Opts}, Rows, Columns, Inputs) ->
+    {{ok, [{rows, Rows}, {columns, Columns}]}, Inputs};
+handle_request({get_geometry, rows}, Rows, _Columns, Inputs) ->
+    {Rows, Inputs};
+handle_request({get_geometry, columns}, _Rows, Columns, Inputs) ->
+    {Columns, Inputs};
+handle_request(_Request, _Rows, _Columns, Inputs) ->
     {ok, Inputs}.
+
+column_widths(IoData) ->
+    [First | _] = line_column_widths(IoData),
+    First.
+
+line_column_widths(IoData) ->
+    [
+        [length(Column) || Column <- inner_columns(Line)]
+     || Line <- non_empty_lines(IoData)
+    ].
+
+line_widths(IoData) ->
+    [length(Line) || Line <- non_empty_lines(IoData)].
+
+plain(IoData) ->
+    binary_to_list(
+        re:replace(
+            unicode:characters_to_binary(IoData),
+            <<"\e\\[[0-9;]*[A-Za-z]">>,
+            <<>>,
+            [global, {return, binary}]
+        )
+    ).
+
+non_empty_lines(IoData) ->
+    [Line || Line <- string:split(plain(IoData), "\n", all), Line =/= ""].
+
+inner_columns(Line) ->
+    Parts = string:split(Line, "|", all),
+    lists:sublist(Parts, 2, erlang:max(length(Parts) - 2, 0)).


### PR DESCRIPTION

# Before

<img width="1919" height="1011" alt="image" src="https://github.com/user-attachments/assets/fb8b3061-6439-4784-8728-5b074a9d388e" />

# After

<img width="1916" height="1003" alt="image" src="https://github.com/user-attachments/assets/438087e3-658a-4cd1-9411-8370873fd4bf" >


This should be the last feature release for the 1.x series. Subsequent work will focus on developing the 2.x line, with new CLI modes added to be more agent/AI-friendly.